### PR TITLE
typo fixes for manpage and --help text

### DIFF
--- a/re2c/doc/manpage.rst.in
+++ b/re2c/doc/manpage.rst.in
@@ -76,7 +76,7 @@ OPTIONS
 
 ``-i --no-debug-info``
     Do not output ``#line`` information. This is
-    usefull when you want use a CMS tool with the ``re2c`` output which you
+    useful when you want use a CMS tool with the ``re2c`` output which you
     might want if you do not require your users to have ``re2c`` themselves
     when building from your source.
 
@@ -272,7 +272,7 @@ depends on a particular use case.
 
 ``YYDEBUG (state, current)``
     This is only needed if the ``-d`` flag was
-    specified. It allows to easily debug the generated parser by calling a
+    specified. It allows one to easily debug the generated parser by calling a
     user defined function for every state. The function should have the
     following signature: ``void YYDEBUG (int state, char current)``. The first
     parameter receives the state or -1 and the second parameter receives the
@@ -372,7 +372,7 @@ while ``[^]`` matches any valid code point (not code unit) and can consume multi
 code units. In fact, when variable-length encoding is used, ``*``
 is the only possible way to match invalid input character (see ``ENCODINGS`` for details).
 
-If ``-c`` is active then each regular expression is preceeded by a list
+If ``-c`` is active then each regular expression is preceded by a list
 of comma separated condition names. Besides normal naming rules there
 are two special cases: ``<*>`` (such rules are merged to all conditions)
 and ``<>`` (such the rule cannot have an associated regular expression,
@@ -464,17 +464,17 @@ INPLACE CONFIGURATIONS
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ``re2c:condprefix = yyc;``
-    Allows to specify the prefix used for
+    Allows one to specify the prefix used for
     condition labels. That is this text is prepended to any condition label
     in the generated output file.
 
 ``re2c:condenumprefix = yyc;``
-    Allows to specify the prefix used for
+    Allows one to specify the prefix used for
     condition values. That is this text is prepended to any condition enum
     value in the generated output file.
 
 ``re2c:cond:divider = "/* *********************************** */";``
-    Allows to customize the devider for condition blocks. You can use ``@@``
+    Allows one to customize the devider for condition blocks. You can use ``@@``
     to put the name of the condition or customize the placeholder using
     ``re2c:cond:divider@cond``.
 
@@ -483,7 +483,7 @@ INPLACE CONFIGURATIONS
     replaced with the condition name in ``re2c:cond:divider``.
 
 ``re2c:cond:goto = "goto @@;";``
-    Allows to customize the condition goto statements used with ``:=>`` style rules. You can use ``@@``
+    Allows one to customize the condition goto statements used with ``:=>`` style rules. You can use ``@@``
     to put the name of the condition or ustomize the placeholder using
     ``re2c:cond:goto@cond``. You can also change this to ``continue;``, which
     would allow you to continue with the next loop cycle including any code
@@ -493,14 +493,14 @@ INPLACE CONFIGURATIONS
     Spcifies the placeholder that will be replaced with the condition label in ``re2c:cond:goto``.
 
 ``re2c:indent:top = 0;``
-    Specifies the minimum number of indendation to
+    Specifies the minimum number of indentation to
     use. Requires a numeric value greater than or equal zero.
 
 ``re2c:indent:string = "\t";``
-    Specifies the string to use for indendation. Requires a string that should
+    Specifies the string to use for indentation. Requires a string that should
     contain only whitespace unless you need this for external tools. The easiest
     way to specify spaces is to enclude them in single or double quotes.
-    If you do  not want any indendation at all you can simply set this to "".
+    If you do not want any indentation at all you can simply set this to "".
 
 ``re2c:yych:conversion = 0;``
     When this setting is non zero, then ``re2c`` automatically generates
@@ -520,7 +520,7 @@ INPLACE CONFIGURATIONS
 
 ``re2c:yyfill:check = 1;``
     This can be set 0 to suppress output of the
-    pre condition using ``YYCURSOR`` and ``YYLIMIT`` which becomes usefull when
+    pre condition using ``YYCURSOR`` and ``YYLIMIT`` which becomes useful when
     ``YYLIMIT + YYMAXFILL`` is always accessible.
 
 ``re2c:define:YYFILL = "YYFILL";``
@@ -557,7 +557,7 @@ INPLACE CONFIGURATIONS
     label has been generated.
 
 ``re2c:labelprefix = "yy";``
-    Allows to change the prefix of numbered
+    Allows one to change the prefix of numbered
     labels. The default is ``yy`` and can be set any string that is a valid
     label.
 
@@ -584,7 +584,7 @@ INPLACE CONFIGURATIONS
 
 ``re2c:yych:conversion = 0;``
     When the input uses signed characters and
-    ``-s`` or ``-b`` switches are in effect re2c allows to automatically convert
+    ``-s`` or ``-b`` switches are in effect re2c allows one to automatically convert
     to the unsigned character type that is then necessary for its internal
     single character. When this setting is zero or an empty string the
     conversion is disabled. Using a non zero number the conversion is taken
@@ -599,22 +599,22 @@ INPLACE CONFIGURATIONS
     Enumeration used for condition support with ``-c`` mode.
 
 ``re2c:define:YYCTXMARKER = "YYCTXMARKER";``
-    Allows to overwrite the
+    Allows one to overwrite the
     define ``YYCTXMARKER`` and thus avoiding it by setting the value to the
     actual code needed.
 
 ``re2c:define:YYCTYPE = "YYCTYPE";``
-    Allows to overwrite the define
+    Allows one to overwrite the define
     ``YYCTYPE`` and thus avoiding it by setting the value to the actual code
     needed.
 
 ``re2c:define:YYCURSOR = "YYCURSOR";``
-    Allows to overwrite the define
+    Allows one to overwrite the define
     ``YYCURSOR`` and thus avoiding it by setting the value to the actual code
     needed.
 
 ``re2c:define:YYDEBUG = "YYDEBUG";``
-    Allows to overwrite the define
+    Allows one to overwrite the define
     ``YYDEBUG`` and thus avoiding it by setting the value to the actual code
     needed.
 
@@ -679,29 +679,29 @@ INPLACE CONFIGURATIONS
     omitted. If non-zero, both argument and semicolon are generated.
 
 ``re2c:define:YYLIMIT = "YYLIMIT";``
-    Allows to overwrite the define
+    Allows one to overwrite the define
     ``YYLIMIT`` and thus avoiding it by setting the value to the actual code
     needed.
 
 ``re2c:define:YYMARKER = "YYMARKER";``
-    Allows to overwrite the define
+    Allows one to overwrite the define
     ``YYMARKER`` and thus avoiding it by setting the value to the actual code
     needed.
 
 ``re2c:label:yyFillLabel = "yyFillLabel";``
-    Allows to overwrite the name of the label ``yyFillLabel``.
+    Allows one to overwrite the name of the label ``yyFillLabel``.
 
 ``re2c:label:yyNext = "yyNext";``
-    Allows to overwrite the name of the label ``yyNext``.
+    Allows one to overwrite the name of the label ``yyNext``.
 
 ``re2c:variable:yyaccept = yyaccept;``
-    Allows to overwrite the name of the variable ``yyaccept``.
+    Allows one to overwrite the name of the variable ``yyaccept``.
 
 ``re2c:variable:yybm = "yybm";``
-    Allows to overwrite the name of the variable ``yybm``.
+    Allows one to overwrite the name of the variable ``yybm``.
 
 ``re2c:variable:yych = "yych";``
-    Allows to overwrite the name of the variable ``yych``.
+    Allows one to overwrite the name of the variable ``yych``.
 
 ``re2c:variable:yyctable = "yyctable";``
     When both ``-c`` and ``-g`` are active then ``re2c`` uses this variable to generate a static jump table
@@ -711,7 +711,7 @@ INPLACE CONFIGURATIONS
     Deprecated.
 
 ``re2c:variable:yytarget = "yytarget";``
-    Allows to overwrite the name of the variable ``yytarget``.
+    Allows one to overwrite the name of the variable ``yytarget``.
 
 
 
@@ -861,7 +861,7 @@ precondition. The precondition is given by the interface define
 There are two special rule types. First, the rules of the condition ``<*>``
 are merged to all conditions (note that they have lower priority than
 other rules of that condition). And second the empty condition list
-allows to provide a code block that does not have a scanner part.
+allows one to provide a code block that does not have a scanner part.
 Meaning it does not allow any regular expression. The condition value
 referring to this special block is always the one with the enumeration
 value 0. This way the code of this special rule can be used to
@@ -869,11 +869,11 @@ initialize a scanner. It is in no way necessary to have these rules: but
 sometimes it is helpful to have a dedicated uninitialized condition
 state.
 
-Non empty rules allow to specify the new condition, which makes them
+Non empty rules allow one to specify the new condition, which makes them
 transition rules. Besides generating calls for the define
 ``YYSETCONDTITION`` no other special code is generated.
 
-There is another kind of special rules that allow to prepend code to any
+There is another kind of special rules that allow one to prepend code to any
 code block of all rules of a certain set of conditions or to all code
 blocks to all rules. This can be helpful when some operation is common
 among rules. For instance this can be used to store the length of the
@@ -959,7 +959,7 @@ GENERIC INPUT API
 ``re2c`` usually operates on input using pointer-like primitives
 ``YYCURSOR``, ``YYMARKER``, ``YYCTXMARKER`` and ``YYLIMIT``.
 
-Generic input API (enabled with ``--input custom`` switch) allows to
+Generic input API (enabled with ``--input custom`` switch) allows one to
 customize input operations. In this mode, ``re2c`` will express all
 operations on input in terms of the following primitives:
 

--- a/re2c/src/conf/msg.cc
+++ b/re2c/src/conf/msg.cc
@@ -89,7 +89,7 @@ void usage ()
 	"-g     --computed-gotos Implies -b. Generate computed goto code (only useable\n"
 	"                        with gcc).\n"
 	"\n"
-	"-i     --no-debug-info  Do not generate '#line' info (usefull for versioning).\n"
+	"-i     --no-debug-info  Do not generate '#line' info (useful for versioning).\n"
 	"\n"
 	"-o of  --output=of      Specify the output file (of) instead of stdout\n"
 	"\n"


### PR DESCRIPTION
While working to update the re2c package in debian, the package checker (lintian) complained about a bunch of [common](https://lintian.debian.org/tags/spelling-error-in-manpage.html) [misspellings](https://lintian.debian.org/tags/spelling-error-in-binary.html) in the manpage and --help text. Nothing urgent, but since I was patching them on the debian end anyway I figured it couldn't hurt to create a pull request here as well.