### PR TITLE
Fix #158 Inconsistent forward declaration of struct/class vs definition

### DIFF
--- a/re2c/src/codegen/bitmap.h
+++ b/re2c/src/codegen/bitmap.h
@@ -10,8 +10,8 @@ namespace re2c
 
 struct Go;
 struct Span;
-class State;
-class OutputFile;
+struct State;
+struct OutputFile;
 
 class BitMap
 {

--- a/re2c/src/codegen/go.h
+++ b/re2c/src/codegen/go.h
@@ -13,7 +13,7 @@ namespace re2c
 {
 
 class BitMap;
-class State;
+struct State;
 struct If;
 
 struct Span

--- a/re2c/src/ir/adfa/action.h
+++ b/re2c/src/ir/adfa/action.h
@@ -12,7 +12,7 @@ namespace re2c
 
 struct OutputFile;
 class RuleOp;
-class State;
+struct State;
 
 struct Initial
 {

--- a/re2c/src/ir/nfa/nfa.h
+++ b/re2c/src/ir/nfa/nfa.h
@@ -8,9 +8,9 @@
 namespace re2c
 {
 
-struct Range;
-struct RegExp;
-struct RuleOp;
+class Range;
+class RegExp;
+class RuleOp;
 
 struct nfa_state_t
 {


### PR DESCRIPTION
structs State and OutputFile forward declared as class.
classes Range, RegExp and RuleOp forward declared as struct.

Fixed forward declarations.