### PR TITLE
Fix #160 - Open text files with "wb" causes issues on Windows

### DIFF
--- a/re2c/src/codegen/output.cc
+++ b/re2c/src/codegen/output.cc
@@ -71,7 +71,7 @@ bool OutputFile::open ()
 	}
 	else
 	{
-		file = fopen (file_name, "wb");
+		file = fopen (file_name, "w");
 	}
 	return file != NULL;
 }
@@ -346,7 +346,7 @@ HeaderFile::HeaderFile (const char * fn)
 
 bool HeaderFile::open ()
 {
-	file = fopen (file_name, "wb");
+	file = fopen (file_name, "w");
 	return file != NULL;
 }
 


### PR DESCRIPTION
Text files need to be opened for writing with "w", so that stdio does
the right thing in respect to the correct line endings for the current OS.
("\r\n" in Windows, "\n" in Linux).