### PR TITLE
re2c: cleanup a few clang ++ warnings

### DIFF
--- a/re2c/src/codegen/bitmap.h
+++ b/re2c/src/codegen/bitmap.h
@@ -10,7 +10,7 @@ namespace re2c {
 
 struct Go;
 struct Span;
-class State;
+struct State;
 class OutputFile;
 
 struct bitmap_t

--- a/re2c/src/codegen/go.h
+++ b/re2c/src/codegen/go.h
@@ -14,9 +14,9 @@ namespace re2c
 {
 
 struct DFA;
-class bitmap_t;
+struct bitmap_t;
 class bitmaps_t;
-class State;
+struct State;
 struct If;
 
 struct Span

--- a/re2c/src/codegen/print.cc
+++ b/re2c/src/codegen/print.cc
@@ -72,7 +72,7 @@ void prtChOrHex(std::ostream& o, uint32_t c, uint32_t szcunit, bool ebcdic, bool
 	}
 }
 
-void prtChOrHexForSpan(std::ostream& o, uint32_t c, uint32_t szcunit, bool ebcdic, bool dot)
+static void prtChOrHexForSpan(std::ostream& o, uint32_t c, uint32_t szcunit, bool ebcdic, bool dot)
 {
 	if (!ebcdic && c != ']' && is_print(c)) {
 		prtCh(o, c, dot);

--- a/re2c/src/conf/warn.h
+++ b/re2c/src/conf/warn.h
@@ -9,7 +9,7 @@
 
 namespace re2c {
 
-struct path_t;
+class path_t;
 struct Skeleton;
 
 #define RE2C_WARNING_TYPES \

--- a/re2c/src/ir/adfa/action.h
+++ b/re2c/src/ir/adfa/action.h
@@ -11,8 +11,8 @@
 namespace re2c
 {
 
-struct OutputFile;
-class State;
+class OutputFile;
+struct State;
 
 struct Initial
 {

--- a/re2c/src/ir/adfa/adfa.h
+++ b/re2c/src/ir/adfa/adfa.h
@@ -20,7 +20,7 @@ namespace re2c
 {
 
 struct Output;
-struct OutputFile;
+class OutputFile;
 struct dfa_t;
 
 struct State

--- a/re2c/src/ir/regexp/encoding/range_suffix.h
+++ b/re2c/src/ir/regexp/encoding/range_suffix.h
@@ -9,7 +9,7 @@
 
 namespace re2c {
 
-class RegExp;
+struct RegExp;
 
 struct RangeSuffix
 {

--- a/re2c/src/ir/regexp/encoding/utf16/utf16_regexp.h
+++ b/re2c/src/ir/regexp/encoding/utf16/utf16_regexp.h
@@ -6,7 +6,7 @@
 namespace re2c {
 
 class Range;
-class RegExp;
+struct RegExp;
 
 const RegExp * UTF16Symbol(utf16::rune r);
 const RegExp * UTF16Range(const Range * r);

--- a/re2c/src/ir/regexp/encoding/utf8/utf8_regexp.h
+++ b/re2c/src/ir/regexp/encoding/utf8/utf8_regexp.h
@@ -6,7 +6,7 @@
 namespace re2c {
 
 class Range;
-class RegExp;
+struct RegExp;
 
 const RegExp * UTF8Symbol(utf8::rune r);
 const RegExp * UTF8Range(const Range * r);

--- a/re2c/src/ir/regexp/regexp.cc
+++ b/re2c/src/ir/regexp/regexp.cc
@@ -113,7 +113,6 @@ const RegExp *Scanner::cls(const Range *r) const
 				break;
 			case EMPTY_CLASS_ERROR:
 				fatal("empty character class");
-				break;
 		}
 	}
 

--- a/re2c/src/ir/skeleton/skeleton.h
+++ b/re2c/src/ir/skeleton/skeleton.h
@@ -26,8 +26,8 @@ namespace re2c
 struct dfa_t;
 struct dfa_state_t;
 struct DFA;
-struct OutputFile;
-struct path_t;
+class OutputFile;
+class path_t;
 
 typedef local_increment_t<uint8_t> local_inc;
 

--- a/re2c/src/parse/scanner.h
+++ b/re2c/src/parse/scanner.h
@@ -15,8 +15,8 @@ namespace re2c
 {
 
 class Range;
-class RegExp;
-struct OutputFile;
+struct RegExp;
+class OutputFile;
 
 struct ScannerState
 {
@@ -106,11 +106,11 @@ public:
 
 	uint32_t get_cline() const;
 	const std::string & get_fname () const;
-	void fatal_at(uint32_t line, ptrdiff_t ofs, const char *msg) const;
-	void fatalf_at(uint32_t line, const char*, ...) const RE2C_GXX_ATTRIBUTE ((format (printf, 3, 4)));
-	void fatalf(const char*, ...) const RE2C_GXX_ATTRIBUTE ((format (printf, 2, 3)));
-	void fatal(const char*) const;
-	void fatal(ptrdiff_t, const char*) const;
+	void fatal_at(uint32_t line, ptrdiff_t ofs, const char *msg) const RE2C_GXX_ATTRIBUTE ((noreturn));
+	void fatalf_at(uint32_t line, const char*, ...) const RE2C_GXX_ATTRIBUTE ((format (printf, 3, 4))) RE2C_GXX_ATTRIBUTE ((noreturn));
+	void fatalf(const char*, ...) const RE2C_GXX_ATTRIBUTE ((format (printf, 2, 3))) RE2C_GXX_ATTRIBUTE ((noreturn));
+	void fatal(const char*) const RE2C_GXX_ATTRIBUTE ((noreturn));
+	void fatal(ptrdiff_t, const char*) const RE2C_GXX_ATTRIBUTE ((noreturn));
 
 	const RegExp * mkDiff (const RegExp * e1, const RegExp * e2) const;
 	const RegExp * mkDot () const;


### PR DESCRIPTION
Found those as:

    $ make CXXFLAGS="-Weverything -Werror -Wno-gnu-statement-expression -Wno-nested-anon-types"

- cleaned struct<->class declaration mismatch
- 'static' around local function
- 'RE2C_GXX_ATTRIBUTE ((noreturn))' around functions known to fail

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>