### PR TITLE
Add const qualifier to operator() in newver_cmp_t

### DIFF
--- a/re2c/src/dfa/closure.h
+++ b/re2c/src/dfa/closure.h
@@ -38,7 +38,7 @@ struct newver_t
 struct newver_cmp_t
 {
 	tagtree_t &history;
-	bool operator()(const newver_t &x, const newver_t &y)
+	bool operator()(const newver_t &x, const newver_t &y) const
 	{
 		if (x.tag < y.tag) return true;
 		if (x.tag > y.tag) return false;


### PR DESCRIPTION
I was getting an error with newver_cmp_t's operator() in certain compilers due to losing "const-volatile qualifiers".