### PR TITLE
Fix for possible invalidated iterator after resize

### DIFF
--- a/re2c/src/dfa/closure.cc
+++ b/re2c/src/dfa/closure.cc
@@ -202,7 +202,6 @@ void raw_closure(const closure_t &init, closure_t &done, closure_t *shadow,
 	// drop "inner" states (non-final without outgoing non-epsilon transitions)
 	j = std::partition(b, e, clos_t::ran);
 	e = std::partition(j, e, clos_t::fin);
-	done.resize(static_cast<size_t>(e - b));
 
 	// drop all final states except one; mark dropped rules as shadowed
 	// see note [at most one final item per closure]
@@ -213,6 +212,9 @@ void raw_closure(const closure_t &init, closure_t &done, closure_t *shadow,
 			rules[i->state->rule].shadow.insert(l);
 		}
 		done.resize(static_cast<size_t>(j - b) + 1);
+	} else {
+		// if there were no final states, only drop "inner" states
+		done.resize(static_cast<size_t>(e - b));
 	}
 }
 


### PR DESCRIPTION
Avoids potentially invalid iterator after vector resize. Should double check that the logic for this is still sound. From what I can tell, e acts like done.end() and won't be included in the sorted elements. Since e >= j, resize j-b+1 will cover dropping the same elements as resize e-b,  if e != j. Otherwise, if e == j then either all states after the first partition call need to be dropped with resize e-b, or there are no states to be dropped and the resize will do nothing.