### PR TITLE
Makefile.am: create target directory before writing into it

### DIFF
--- a/re2c/Makefile.am
+++ b/re2c/Makefile.am
@@ -252,6 +252,7 @@ $(BOOTSTRAP_PARSER): $(CUSTOM_PARSER)
 		$(top_srcdir)/$(CUSTOM_PARSER);
 
 .re.cc:
+	$(AM_V_at)$(MKDIR_P) $(dir $@)
 	$(AM_V_GEN) if test -x $(RE2C); \
 	then \
 		$(top_builddir)/$(RE2C) $(RE2CFLAGS) -o $@ $< && \


### PR DESCRIPTION
In some situations src/parse/ may not exist before a file is copied into the
directory. Ensure that this doesn't happen by creating the directory first.