### PR TITLE
Makefile.am: create target directory before writing into it

### DIFF
--- a/re2c/Makefile.am
+++ b/re2c/Makefile.am
@@ -228,6 +228,7 @@ CLEANFILES = \
 	$(DOC)
 
 $(AUTOGEN_PARSER): $(CUSTOM_PARSER)
+	$(AM_V_at)$(MKDIR_P) $(dir $@)
 	$(AM_V_GEN) if test $(BISON) = "no"; \
 	then \
 		cp $(top_srcdir)/$(BOOTSTRAP_PARSER) $@ && \


### PR DESCRIPTION
In some situations src/parse/ may not exist before a file is copied into the
directory. Ensure that this doesn't happen by creating the directory first.