### PR TITLE
configure.ac: enable xz tarballs instead of gzip by default

### DIFF
--- a/re2c/configure.ac
+++ b/re2c/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([re2c],[1.1.1],[re2c-general@lists.sourceforge.net])
-AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_INIT_AUTOMAKE([foreign subdir-objects dist-xz no-dist-gzip])
 AM_SILENT_RULES([yes])
 
 


### PR DESCRIPTION
`xz` compresses twice as good as `gzip` on `re2c` sources:

```
$ ls -lh *1.1.1*
4,8M re2c-1.1.1.tar.gz
2,5M re2c-1.1.1.tar.xz
```

Switch `make dist` to `xz by default. `gzip` is still available
via `make dist-gzip`.

Reported-by: rofl0r
Bug: https://github.com/skvadrik/re2c/issues/221
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>