### PR TITLE
Package LICENSE file in the release tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -270,6 +270,7 @@ EXTRA_DIST = \
 	$(re2c_CUSTOM) \
 	$(re2c_SRC_DOC_EXT) \
 	CHANGELOG \
+	LICENSE \
 	NO_WARRANTY \
 	README.md \
 	autogen.sh \


### PR DESCRIPTION
This is important when re2c is packaged in distributions, so that one can
quickly check what license the re2c is distributed under. Distributions
typically use the release tarball, not the git repository, and so this commit
puts the LICENSE file into the release tarball also.