### PR TITLE
.travis.yml: enable ccache to speed up incremental builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 
+# speed up incremental builds
+cache: ccache
+
 compiler:
  - gcc
  - clang


### PR DESCRIPTION
I'm not sure what would be the actual benefit. Let's try it in action!

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>