### PR TITLE
Add build scripts using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,11 @@ ac_config_headers("config.h")
 
 # Makefile.am
 set(RE2C_STDLIB_DIR "${CMAKE_INSTALL_PREFIX}/share/re2c/stdlib")
-add_compile_definitions("RE2C_STDLIB_DIR=\"${RE2C_STDLIB_DIR}\"")
-add_compile_definitions($<$<CONFIG:Debug>:RE2C_DEBUG>)
+add_compile_definitions(
+  "RE2C_STDLIB_DIR=\"${RE2C_STDLIB_DIR}\""
+  $<$<CONFIG:Debug>:RE2C_DEBUG>
+  $<$<CONFIG:RelWithDebInfo>:RE2C_DEBUG>
+)
 include_directories(. "${CMAKE_CURRENT_BINARY_DIR}")
 
 # sources

--- a/__cmakebuild.sh
+++ b/__cmakebuild.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+builddir=__build
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_asan.sh
+++ b/__cmakebuild_asan.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+builddir=__build_asan
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_CXX_FLAGS="-fsanitize=address" \
+    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address" \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_check_headers.sh
+++ b/__cmakebuild_check_headers.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+builddir=__build_check_headers
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    && cmake --build . -j$(nproc)
+
+for h in $(find ../src/ ../lib/ -name '*.h*'); do
+    echo "CHECKING $h"
+    g++ -I. -I.. -c $h -o foo.o || exit 1
+done
+
+rm -f foo.o
+
+cd ..

--- a/__cmakebuild_clang.sh
+++ b/__cmakebuild_clang.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+builddir=__build_clang
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_clang_msan.sh
+++ b/__cmakebuild_clang_msan.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+builddir=__build_clang_msan
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2"
+    -DCMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2" \
+    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2" \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_glibcxx_debug.sh
+++ b/__cmakebuild_glibcxx_debug.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+builddir=__build_glibcxx_debug
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_CXX_FLAGS="-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC" \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_iwyu.sh
+++ b/__cmakebuild_iwyu.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+builddir=__build_iwyu
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="include-what-you-use;-Xiwyu;--check_also='*.re';-Xiwyu;--check_also='*.y';-Xiwyu;--no_comments" \
+    && cmake --build . -j$(nproc) 2>log
+cd ..

--- a/__cmakebuild_lsan.sh
+++ b/__cmakebuild_lsan.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+builddir=__build_lsan
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_CXX_FLAGS="-fsanitize=leak" \
+    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=leak" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=leak" \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_m32.sh
+++ b/__cmakebuild_m32.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+builddir=__build_m32
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_CXX_FLAGS="-m32" \
+    -DCMAKE_EXE_LINKER_FLAGS="-m32" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-m32" \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_mingw.sh
+++ b/__cmakebuild_mingw.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+builddir=__build_mingw
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DBUILD_SHARED_LIBS=no \
+    -DCMAKE_EXE_LINKER_FLAGS="-static -static-libstdc++ -static-libgcc" \
+    -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-cross-mingw32-linux.cmake \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_nodebug.sh
+++ b/__cmakebuild_nodebug.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+builddir=__build_nodebug
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DRE2C_BUILD_LIBS=yes \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_redundant_exports.sh
+++ b/__cmakebuild_redundant_exports.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+builddir=__build_redundant_exports
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_C_FLAGS="-ffunction-sections -fdata-sections" \
+    -DCMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections" \
+    -DCMAKE_EXE_LINKER_FLAGS="-Wl,--gc-sections -Wl,--print-gc-sections" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--gc-sections -Wl,--print-gc-sections" \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/__cmakebuild_ubsan.sh
+++ b/__cmakebuild_ubsan.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+builddir=__build_ubsan
+rm -rf $builddir
+mkdir $builddir
+
+cd $builddir
+cmake .. \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DRE2C_BUILD_LIBS=yes \
+    -DCMAKE_CXX_FLAGS="-fsanitize=undefined" \
+    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=undefined" \
+    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=undefined" \
+    && cmake --build . -j$(nproc)
+cd ..

--- a/cmake/Toolchain-cross-mingw32-linux.cmake
+++ b/cmake/Toolchain-cross-mingw32-linux.cmake
@@ -1,0 +1,19 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+SET(COMPILER_PREFIX "i686-w64-mingw32")
+
+# which compilers to use for C and C++
+find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
+
+# here is the target environment located
+SET(CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH} /usr/${COMPILER_PREFIX})
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search.
+# programs in the host environment
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cmake/Toolchain-cross-mingw64-linux.cmake
+++ b/cmake/Toolchain-cross-mingw64-linux.cmake
@@ -1,0 +1,19 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+SET(COMPILER_PREFIX "x86_64-w64-mingw32")
+
+# which compilers to use for C and C++
+find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
+
+# here is the target environment located
+SET(CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH} /usr/${COMPILER_PREFIX})
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search.
+# programs in the host environment
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Follow-up to #275.

This adds `__cmakebuild*.sh` scripts analogous to the existing `__build*.sh` scripts, for a variety of scenarios.