### PR TITLE
configure.ac: store auxiliary configure files in build-aux/

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
 AC_INIT([re2c],[1.3],[re2c-general@lists.sourceforge.net])
+AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign subdir-objects dist-xz no-dist-gzip])
 AM_SILENT_RULES([yes])
 


### PR DESCRIPTION
This makes root directory less cluttered. Autoconf-specific
scripts like 'config.guess'. 'install-sh' and friends
are moved to build-aux/ now.