### PR TITLE
autogen.sh: always attempt to create m4/ directory

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 git clean -fX
+mkdir -p m4
 autoreconf -i -W all


### PR DESCRIPTION
On a fresh checkout `autogen.sh` complains about missing `m4`:

```
$ ./autogen.sh
aclocal-1.16: warning: couldn't open directory 'm4': No such file or directory
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
...
```

The change always attempts to create the directory.