### PR TITLE
Fix for old compilers like gcc 4.2 and clang 3.4

### DIFF
--- a/src/dfa/closure_posix.h
+++ b/src/dfa/closure_posix.h
@@ -125,7 +125,8 @@ void init_gor1(ctx_t &ctx)
     // init: push configurations ordered by POSIX precedence (highest on top)
     state.clear();
     std::sort(reach.begin(), reach.end(), cmp_gor1_t<ctx_t>(ctx));
-    for (typename ctx_t::rcconfiter_t c = reach.rbegin(); c != reach.rend(); ++c) {
+    typename ctx_t::rcconfiter_t c = reach.rbegin(), e = reach.rend();
+    for (; c != e; ++c) {
         nfa_state_t *q = c->state;
         if (q->clos == NOCLOS) {
             q->clos = static_cast<uint32_t>(state.size());


### PR DESCRIPTION
Hi, I'm the MacPorts maintainer of re2c. We discussed a problem a few years ago in #198 where old versions of gcc were unable to compile your code, and you committed a simple fix but warned that it might break in the future.

It did, and we received a couple reports about it. It was reported last year that [re2c 1.2.1 didn't build with gcc 4.2](https://trac.macports.org/ticket/58993) on Mac OS X 10.4 on PowerPC:

```
./src/dfa/closure_posix.h:128: error: no match for 'operator!=' in 'c != std::vector<_Tp, _Alloc>::rend() [with _Tp = re2c::clos_t, _Alloc = std::allocator<re2c::clos_t>]()'
```

I had forgotten about our previous discussion and worked around the problem by using a newer compiler, but then it was reported a few days ago that [re2c 1.3 didn't build with clang 3.4](https://trac.macports.org/ticket/60755) on Mac OS X 10.4 on Intel:

```
./src/dfa/closure_posix.h:128:61: error: invalid operands to binary expression ('typename determ_context_t<phistory_t>::rcconfiter_t' (aka 'reverse_iterator<const_iterator>') and 'reverse_iterator' (aka 'reverse_iterator<iterator>'))
    for (typename ctx_t::rcconfiter_t c = reach.rbegin(); c != reach.rend(); ++c) {
```

This prompted me to investigate and find our previous discussion again and to try the patch in this PR, which worked for me. I hope you'll accept it.