### PR TITLE
Fix UTF-8 decode for 4bytes rune

### DIFF
--- a/src/encoding/utf8/utf8.cc
+++ b/src/encoding/utf8/utf8.cc
@@ -8,8 +8,8 @@ const uint32_t utf8::ERROR = 0xFFFDu;
 const utf8::rune utf8::MAX_1BYTE_RUNE = 0x7Fu;
 const utf8::rune utf8::MAX_2BYTE_RUNE = 0x7FFu;
 const utf8::rune utf8::MAX_3BYTE_RUNE = 0xFFFFu;
-const utf8::rune utf8::MAX_4BYTE_RUNE = 0x10FFFFu;
-const utf8::rune utf8::MAX_RUNE       = utf8::MAX_4BYTE_RUNE;
+const utf8::rune utf8::MAX_4BYTE_RUNE = 0x1FFFFFu;
+const utf8::rune utf8::MAX_RUNE       = 0x10FFFFu;
 
 const uint32_t utf8::PREFIX_1BYTE = 0u;    // 0000 0000
 const uint32_t utf8::INFIX        = 0x80u; // 1000 0000

--- a/test/encodings/utf8_literals.c
+++ b/test/encodings/utf8_literals.c
@@ -17,11 +17,8 @@ int lex(const char *YYCURSOR)
 	case 0xCE:	goto yy6;
 	case 0xD0:	goto yy7;
 	case 0xD1:	goto yy8;
-	case 0xE3:	goto yy9;
-	case 0xE4:	goto yy10;
-	case 0xE8:	goto yy11;
-	case 0xED:	goto yy12;
-	case 0xEF:	goto yy13;
+	case 0xEF:	goto yy9;
+	case 0xF0:	goto yy10;
 	default:	goto yy2;
 	}
 yy2:
@@ -30,326 +27,335 @@ yy3:
 	{ return -1; }
 yy4:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy14;
+	if (yych <= 0x00) goto yy11;
 	goto yy3;
 yy5:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy16;
+	if (yych <= 0x00) goto yy13;
 	goto yy3;
 yy6:
 	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0x88:	goto yy18;
+	case 0x88:	goto yy15;
 	default:	goto yy3;
 	}
 yy7:
 	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0x90:	goto yy20;
-	case 0x9C:	goto yy21;
-	case 0xA1:	goto yy22;
-	case 0xA3:	goto yy23;
+	case 0x90:	goto yy17;
+	case 0x9C:	goto yy18;
+	case 0xA1:	goto yy19;
+	case 0xA3:	goto yy20;
 	default:	goto yy3;
 	}
 yy8:
 	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0x81:	goto yy22;
-	case 0xB7:	goto yy24;
+	case 0x81:	goto yy19;
+	case 0xB7:	goto yy21;
 	default:	goto yy3;
 	}
 yy9:
 	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0x9D:	goto yy25;
+	case 0xBD:	goto yy22;
+	case 0xBE:	goto yy23;
 	default:	goto yy3;
 	}
 yy10:
 	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0xB0:	goto yy26;
+	case 0x9D:	goto yy24;
+	case 0xA3:	goto yy25;
+	case 0xA4:	goto yy26;
+	case 0xA8:	goto yy27;
 	default:	goto yy3;
 	}
 yy11:
-	yych = *(YYMARKER = ++YYCURSOR);
-	switch (yych) {
-	case 0xA2:	goto yy27;
-	default:	goto yy3;
-	}
-yy12:
-	yych = *(YYMARKER = ++YYCURSOR);
-	switch (yych) {
-	case 0x8C:	goto yy28;
-	default:	goto yy3;
-	}
-yy13:
-	yych = *(YYMARKER = ++YYCURSOR);
-	switch (yych) {
-	case 0xBD:	goto yy29;
-	case 0xBE:	goto yy30;
-	default:	goto yy3;
-	}
-yy14:
 	++YYCURSOR;
 	{ return 4; }
-yy16:
+yy13:
 	++YYCURSOR;
 	{ return 5; }
-yy18:
+yy15:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy31;
-yy19:
+	if (yych <= 0x00) goto yy28;
+yy16:
 	YYCURSOR = YYMARKER;
 	goto yy3;
+yy17:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD0:	goto yy30;
+	default:	goto yy16;
+	}
+yy18:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD0:	goto yy31;
+	default:	goto yy16;
+	}
+yy19:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD0:	goto yy32;
+	default:	goto yy16;
+	}
 yy20:
 	yych = *++YYCURSOR;
 	switch (yych) {
 	case 0xD0:	goto yy33;
-	default:	goto yy19;
+	default:	goto yy16;
 	}
 yy21:
 	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD0:	goto yy34;
-	default:	goto yy19;
-	}
+	if (yych <= 0x00) goto yy34;
+	goto yy16;
 yy22:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xD0:	goto yy35;
-	default:	goto yy19;
+	case 0xB7:	goto yy36;
+	default:	goto yy16;
 	}
 yy23:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xD0:	goto yy36;
-	default:	goto yy19;
+	case 0x88:	goto yy37;
+	default:	goto yy16;
 	}
 yy24:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy37;
-	goto yy19;
+	switch (yych) {
+	case 0x8C:	goto yy38;
+	default:	goto yy16;
+	}
 yy25:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xB7:	goto yy39;
-	default:	goto yy19;
+	case 0x9D:	goto yy39;
+	default:	goto yy16;
 	}
 yy26:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0x96:	goto yy40;
-	default:	goto yy19;
+	case 0xB0:	goto yy40;
+	default:	goto yy16;
 	}
 yy27:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0x88:	goto yy41;
-	default:	goto yy19;
+	case 0xA2:	goto yy41;
+	default:	goto yy16;
 	}
 yy28:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0x92:	goto yy42;
-	default:	goto yy19;
-	}
-yy29:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xB7:	goto yy43;
-	default:	goto yy19;
-	}
+	++YYCURSOR;
+	{ return 7; }
 yy30:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0x88:	goto yy44;
-	default:	goto yy19;
+	case 0xBD:	goto yy42;
+	default:	goto yy16;
 	}
 yy31:
-	++YYCURSOR;
-	{ return 7; }
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xB0:	goto yy43;
+	default:	goto yy16;
+	}
+yy32:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xB5:	goto yy44;
+	default:	goto yy16;
+	}
 yy33:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xBD:	goto yy45;
-	default:	goto yy19;
+	case 0xBB:	goto yy45;
+	default:	goto yy16;
 	}
 yy34:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xB0:	goto yy46;
-	default:	goto yy19;
-	}
-yy35:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xB5:	goto yy47;
-	default:	goto yy19;
-	}
-yy36:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xBB:	goto yy48;
-	default:	goto yy19;
-	}
-yy37:
 	++YYCURSOR;
 	{ return 6; }
+yy36:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy46;
+	goto yy16;
+yy37:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy48;
+	goto yy16;
+yy38:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x92:	goto yy50;
+	default:	goto yy16;
+	}
 yy39:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy49;
-	goto yy19;
+	switch (yych) {
+	case 0xB7:	goto yy51;
+	default:	goto yy16;
+	}
 yy40:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy51;
-	goto yy19;
+	switch (yych) {
+	case 0x96:	goto yy52;
+	default:	goto yy16;
+	}
 yy41:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy53;
-	goto yy19;
+	switch (yych) {
+	case 0x88:	goto yy53;
+	default:	goto yy16;
+	}
 yy42:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy55;
-	goto yy19;
+	switch (yych) {
+	case 0xD1:	goto yy54;
+	default:	goto yy16;
+	}
 yy43:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy57;
-	goto yy19;
+	switch (yych) {
+	case 0xD1:	goto yy55;
+	default:	goto yy16;
+	}
 yy44:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy59;
-	goto yy19;
+	switch (yych) {
+	case 0xD1:	goto yy56;
+	default:	goto yy16;
+	}
 yy45:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xD1:	goto yy61;
-	default:	goto yy19;
+	case 0xD1:	goto yy57;
+	default:	goto yy16;
 	}
 yy46:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD1:	goto yy62;
-	default:	goto yy19;
-	}
-yy47:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD1:	goto yy63;
-	default:	goto yy19;
-	}
-yy48:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD1:	goto yy64;
-	default:	goto yy19;
-	}
-yy49:
-	++YYCURSOR;
-	{ return 10; }
-yy51:
-	++YYCURSOR;
-	{ return 12; }
-yy53:
-	++YYCURSOR;
-	{ return 11; }
-yy55:
-	++YYCURSOR;
-	{ return 13; }
-yy57:
 	++YYCURSOR;
 	{ return 8; }
-yy59:
+yy48:
 	++YYCURSOR;
 	{ return 9; }
-yy61:
+yy50:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy58;
+	goto yy16;
+yy51:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy60;
+	goto yy16;
+yy52:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy62;
+	goto yy16;
+yy53:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy64;
+	goto yy16;
+yy54:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0x8F:	goto yy65;
-	default:	goto yy19;
+	case 0x8F:	goto yy66;
+	default:	goto yy16;
 	}
+yy55:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x88:	goto yy67;
+	default:	goto yy16;
+	}
+yy56:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x80:	goto yy68;
+	default:	goto yy16;
+	}
+yy57:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x8F:	goto yy69;
+	default:	goto yy16;
+	}
+yy58:
+	++YYCURSOR;
+	{ return 13; }
+yy60:
+	++YYCURSOR;
+	{ return 10; }
 yy62:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0x88:	goto yy66;
-	default:	goto yy19;
-	}
-yy63:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0x80:	goto yy67;
-	default:	goto yy19;
-	}
+	++YYCURSOR;
+	{ return 12; }
 yy64:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0x8F:	goto yy68;
-	default:	goto yy19;
-	}
-yy65:
-	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy69;
-	goto yy19;
+	++YYCURSOR;
+	{ return 11; }
 yy66:
 	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD0:	goto yy71;
-	default:	goto yy19;
-	}
+	if (yych <= 0x00) goto yy70;
+	goto yy16;
 yy67:
 	yych = *++YYCURSOR;
 	switch (yych) {
 	case 0xD0:	goto yy72;
-	default:	goto yy19;
+	default:	goto yy16;
 	}
 yy68:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy73;
-	goto yy19;
+	switch (yych) {
+	case 0xD0:	goto yy73;
+	default:	goto yy16;
+	}
 yy69:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy74;
+	goto yy16;
+yy70:
 	++YYCURSOR;
 	{ return 3; }
-yy71:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xB0:	goto yy75;
-	default:	goto yy19;
-	}
 yy72:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xB3:	goto yy76;
-	default:	goto yy19;
+	case 0xB0:	goto yy76;
+	default:	goto yy16;
 	}
 yy73:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xB3:	goto yy77;
+	default:	goto yy16;
+	}
+yy74:
 	++YYCURSOR;
 	{ return 2; }
-yy75:
-	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy77;
-	goto yy19;
 yy76:
 	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD0:	goto yy79;
-	default:	goto yy19;
-	}
+	if (yych <= 0x00) goto yy78;
+	goto yy16;
 yy77:
-	++YYCURSOR;
-	{ return 1; }
-yy79:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xB5:	goto yy80;
-	default:	goto yy19;
+	case 0xD0:	goto yy80;
+	default:	goto yy16;
 	}
+yy78:
+	++YYCURSOR;
+	{ return 1; }
 yy80:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xD0:	goto yy81;
-	case 0xD1:	goto yy82;
-	default:	goto yy19;
+	case 0xB5:	goto yy81;
+	default:	goto yy16;
 	}
 yy81:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD0:	goto yy82;
+	case 0xD1:	goto yy83;
+	default:	goto yy16;
+	}
+yy82:
 	yych = *++YYCURSOR;
 	switch (yych) {
 	case 0x90:
@@ -399,10 +405,10 @@ yy81:
 	case 0xBC:
 	case 0xBD:
 	case 0xBE:
-	case 0xBF:	goto yy83;
-	default:	goto yy19;
+	case 0xBF:	goto yy84;
+	default:	goto yy16;
 	}
-yy82:
+yy83:
 	yych = *++YYCURSOR;
 	switch (yych) {
 	case 0x80:
@@ -420,12 +426,12 @@ yy82:
 	case 0x8C:
 	case 0x8D:
 	case 0x8E:
-	case 0x8F:	goto yy83;
-	default:	goto yy19;
+	case 0x8F:	goto yy84;
+	default:	goto yy16;
 	}
-yy83:
+yy84:
 	yych = *++YYCURSOR;
-	if (yych >= 0x01) goto yy19;
+	if (yych >= 0x01) goto yy16;
 	++YYCURSOR;
 	{ return 0; }
 }

--- a/test/encodings/utf8_literals.c
+++ b/test/encodings/utf8_literals.c
@@ -12,8 +12,16 @@ int lex(const char *YYCURSOR)
 	YYCTYPE yych;
 	yych = *YYCURSOR;
 	switch (yych) {
-	case 0xD0:	goto yy4;
-	case 0xD1:	goto yy5;
+	case '1':	goto yy4;
+	case '~':	goto yy5;
+	case 0xCE:	goto yy6;
+	case 0xD0:	goto yy7;
+	case 0xD1:	goto yy8;
+	case 0xE3:	goto yy9;
+	case 0xE4:	goto yy10;
+	case 0xE8:	goto yy11;
+	case 0xED:	goto yy12;
+	case 0xEF:	goto yy13;
 	default:	goto yy2;
 	}
 yy2:
@@ -21,184 +29,327 @@ yy2:
 yy3:
 	{ return -1; }
 yy4:
-	yych = *(YYMARKER = ++YYCURSOR);
-	switch (yych) {
-	case 0x90:	goto yy6;
-	case 0x9C:	goto yy8;
-	case 0xA1:	goto yy9;
-	case 0xA3:	goto yy10;
-	default:	goto yy3;
-	}
-yy5:
-	yych = *(YYMARKER = ++YYCURSOR);
-	switch (yych) {
-	case 0x81:	goto yy9;
-	default:	goto yy3;
-	}
-yy6:
 	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy14;
+	goto yy3;
+yy5:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy16;
+	goto yy3;
+yy6:
+	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0xD0:	goto yy11;
-	default:	goto yy7;
+	case 0x88:	goto yy18;
+	default:	goto yy3;
 	}
 yy7:
-	YYCURSOR = YYMARKER;
-	goto yy3;
-yy8:
-	yych = *++YYCURSOR;
+	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0xD0:	goto yy12;
-	default:	goto yy7;
+	case 0x90:	goto yy20;
+	case 0x9C:	goto yy21;
+	case 0xA1:	goto yy22;
+	case 0xA3:	goto yy23;
+	default:	goto yy3;
+	}
+yy8:
+	yych = *(YYMARKER = ++YYCURSOR);
+	switch (yych) {
+	case 0x81:	goto yy22;
+	case 0xB7:	goto yy24;
+	default:	goto yy3;
 	}
 yy9:
-	yych = *++YYCURSOR;
+	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0xD0:	goto yy13;
-	default:	goto yy7;
+	case 0x9D:	goto yy25;
+	default:	goto yy3;
 	}
 yy10:
-	yych = *++YYCURSOR;
+	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0xD0:	goto yy14;
-	default:	goto yy7;
+	case 0xB0:	goto yy26;
+	default:	goto yy3;
 	}
 yy11:
-	yych = *++YYCURSOR;
+	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0xBD:	goto yy15;
-	default:	goto yy7;
+	case 0xA2:	goto yy27;
+	default:	goto yy3;
 	}
 yy12:
-	yych = *++YYCURSOR;
+	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0xB0:	goto yy16;
-	default:	goto yy7;
+	case 0x8C:	goto yy28;
+	default:	goto yy3;
 	}
 yy13:
-	yych = *++YYCURSOR;
+	yych = *(YYMARKER = ++YYCURSOR);
 	switch (yych) {
-	case 0xB5:	goto yy17;
-	default:	goto yy7;
+	case 0xBD:	goto yy29;
+	case 0xBE:	goto yy30;
+	default:	goto yy3;
 	}
 yy14:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xBB:	goto yy18;
-	default:	goto yy7;
-	}
-yy15:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD1:	goto yy19;
-	default:	goto yy7;
-	}
+	++YYCURSOR;
+	{ return 4; }
 yy16:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD1:	goto yy20;
-	default:	goto yy7;
-	}
-yy17:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD1:	goto yy21;
-	default:	goto yy7;
-	}
+	++YYCURSOR;
+	{ return 5; }
 yy18:
 	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD1:	goto yy22;
-	default:	goto yy7;
-	}
+	if (yych <= 0x00) goto yy31;
 yy19:
-	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0x8F:	goto yy23;
-	default:	goto yy7;
-	}
+	YYCURSOR = YYMARKER;
+	goto yy3;
 yy20:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0x88:	goto yy24;
-	default:	goto yy7;
+	case 0xD0:	goto yy33;
+	default:	goto yy19;
 	}
 yy21:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0x80:	goto yy25;
-	default:	goto yy7;
+	case 0xD0:	goto yy34;
+	default:	goto yy19;
 	}
 yy22:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0x8F:	goto yy26;
-	default:	goto yy7;
+	case 0xD0:	goto yy35;
+	default:	goto yy19;
 	}
 yy23:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy27;
-	goto yy7;
+	switch (yych) {
+	case 0xD0:	goto yy36;
+	default:	goto yy19;
+	}
 yy24:
 	yych = *++YYCURSOR;
-	switch (yych) {
-	case 0xD0:	goto yy29;
-	default:	goto yy7;
-	}
+	if (yych <= 0x00) goto yy37;
+	goto yy19;
 yy25:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xD0:	goto yy30;
-	default:	goto yy7;
+	case 0xB7:	goto yy39;
+	default:	goto yy19;
 	}
 yy26:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy31;
-	goto yy7;
+	switch (yych) {
+	case 0x96:	goto yy40;
+	default:	goto yy19;
+	}
 yy27:
-	++YYCURSOR;
-	{ return 3; }
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x88:	goto yy41;
+	default:	goto yy19;
+	}
+yy28:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x92:	goto yy42;
+	default:	goto yy19;
+	}
 yy29:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xB0:	goto yy33;
-	default:	goto yy7;
+	case 0xB7:	goto yy43;
+	default:	goto yy19;
 	}
 yy30:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xB3:	goto yy34;
-	default:	goto yy7;
+	case 0x88:	goto yy44;
+	default:	goto yy19;
 	}
 yy31:
 	++YYCURSOR;
-	{ return 2; }
+	{ return 7; }
 yy33:
 	yych = *++YYCURSOR;
-	if (yych <= 0x00) goto yy35;
-	goto yy7;
+	switch (yych) {
+	case 0xBD:	goto yy45;
+	default:	goto yy19;
+	}
 yy34:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xD0:	goto yy37;
-	default:	goto yy7;
+	case 0xB0:	goto yy46;
+	default:	goto yy19;
 	}
 yy35:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xB5:	goto yy47;
+	default:	goto yy19;
+	}
+yy36:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xBB:	goto yy48;
+	default:	goto yy19;
+	}
+yy37:
+	++YYCURSOR;
+	{ return 6; }
+yy39:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy49;
+	goto yy19;
+yy40:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy51;
+	goto yy19;
+yy41:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy53;
+	goto yy19;
+yy42:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy55;
+	goto yy19;
+yy43:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy57;
+	goto yy19;
+yy44:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy59;
+	goto yy19;
+yy45:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD1:	goto yy61;
+	default:	goto yy19;
+	}
+yy46:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD1:	goto yy62;
+	default:	goto yy19;
+	}
+yy47:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD1:	goto yy63;
+	default:	goto yy19;
+	}
+yy48:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD1:	goto yy64;
+	default:	goto yy19;
+	}
+yy49:
+	++YYCURSOR;
+	{ return 10; }
+yy51:
+	++YYCURSOR;
+	{ return 12; }
+yy53:
+	++YYCURSOR;
+	{ return 11; }
+yy55:
+	++YYCURSOR;
+	{ return 13; }
+yy57:
+	++YYCURSOR;
+	{ return 8; }
+yy59:
+	++YYCURSOR;
+	{ return 9; }
+yy61:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x8F:	goto yy65;
+	default:	goto yy19;
+	}
+yy62:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x88:	goto yy66;
+	default:	goto yy19;
+	}
+yy63:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x80:	goto yy67;
+	default:	goto yy19;
+	}
+yy64:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0x8F:	goto yy68;
+	default:	goto yy19;
+	}
+yy65:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy69;
+	goto yy19;
+yy66:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD0:	goto yy71;
+	default:	goto yy19;
+	}
+yy67:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD0:	goto yy72;
+	default:	goto yy19;
+	}
+yy68:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy73;
+	goto yy19;
+yy69:
+	++YYCURSOR;
+	{ return 3; }
+yy71:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xB0:	goto yy75;
+	default:	goto yy19;
+	}
+yy72:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xB3:	goto yy76;
+	default:	goto yy19;
+	}
+yy73:
+	++YYCURSOR;
+	{ return 2; }
+yy75:
+	yych = *++YYCURSOR;
+	if (yych <= 0x00) goto yy77;
+	goto yy19;
+yy76:
+	yych = *++YYCURSOR;
+	switch (yych) {
+	case 0xD0:	goto yy79;
+	default:	goto yy19;
+	}
+yy77:
 	++YYCURSOR;
 	{ return 1; }
-yy37:
+yy79:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xB5:	goto yy38;
-	default:	goto yy7;
+	case 0xB5:	goto yy80;
+	default:	goto yy19;
 	}
-yy38:
+yy80:
 	yych = *++YYCURSOR;
 	switch (yych) {
-	case 0xD0:	goto yy39;
-	case 0xD1:	goto yy40;
-	default:	goto yy7;
+	case 0xD0:	goto yy81;
+	case 0xD1:	goto yy82;
+	default:	goto yy19;
 	}
-yy39:
+yy81:
 	yych = *++YYCURSOR;
 	switch (yych) {
 	case 0x90:
@@ -248,10 +399,10 @@ yy39:
 	case 0xBC:
 	case 0xBD:
 	case 0xBE:
-	case 0xBF:	goto yy41;
-	default:	goto yy7;
+	case 0xBF:	goto yy83;
+	default:	goto yy19;
 	}
-yy40:
+yy82:
 	yych = *++YYCURSOR;
 	switch (yych) {
 	case 0x80:
@@ -269,25 +420,37 @@ yy40:
 	case 0x8C:
 	case 0x8D:
 	case 0x8E:
-	case 0x8F:	goto yy41;
-	default:	goto yy7;
+	case 0x8F:	goto yy83;
+	default:	goto yy19;
 	}
-yy41:
+yy83:
 	yych = *++YYCURSOR;
-	if (yych >= 0x01) goto yy7;
+	if (yych >= 0x01) goto yy19;
 	++YYCURSOR;
 	{ return 0; }
 }
 
 }
 
+#define TEST(s, i) assert(lex(s) == i)
+
 int main()
 {
-    assert(lex("Аня") == 3);
-    assert(lex("Маша") == 1);
-    assert(lex("Уля") == 2);
-    assert(lex("Сергей") == 0);
-    assert(lex("Сергеы") == 0);
-    assert(lex("сергеЫ") == 0);
+    TEST("Аня", 3);
+    TEST("Маша", 1);
+    TEST("Уля", 2);
+    TEST("1", 4);
+    TEST("~", 5);
+    TEST("ѷ", 6);
+    TEST("Έ", 7);
+    TEST("ｷ", 8);
+    TEST("ﾈ", 9);
+    TEST("𣝷", 10);
+    TEST("𨢈", 11);
+    TEST("𤰖", 12);
+    TEST("𝌒", 13);
+    TEST("Сергей", 0);
+    TEST("Сергеы", 0);
+    TEST("сергеЫ", 0);
     return 0;
 }

--- a/test/encodings/utf8_literals.re
+++ b/test/encodings/utf8_literals.re
@@ -14,6 +14,16 @@ int lex(const char *YYCURSOR)
     "Аня"  end { return 3; }
     "Маша" end { return 1; }
     "Уля"  end { return 2; }
+    "1"  end { return 4; } // 1byte U+31
+    "~"  end { return 5; } // 1byte U+7E
+    "ѷ"  end { return 6; } // 2bytes U+477
+    "Έ"  end { return 7; } // 2bytes U+388
+    "ｷ"  end { return 8; } // 3bytes U+FF77
+    "ﾈ"  end { return 9; } // 3bytes U+FF88
+    "𣝷"  end { return 10; } // 4bytes U+23777
+    "𨢈"  end { return 11; } // 4bytes U+23888
+    "𤰖"  end { return 12; } // 4bytes U+24C16
+    "𝌒"  end { return 13; } // 4bytes U+1D312
 
     [Сс] "ерге" [а-яА-Я] end { return 0; }
 
@@ -21,13 +31,25 @@ int lex(const char *YYCURSOR)
     */
 }
 
+#define TEST(s, i) assert(lex(s) == i)
+
 int main()
 {
-    assert(lex("Аня") == 3);
-    assert(lex("Маша") == 1);
-    assert(lex("Уля") == 2);
-    assert(lex("Сергей") == 0);
-    assert(lex("Сергеы") == 0);
-    assert(lex("сергеЫ") == 0);
+    TEST("Аня", 3);
+    TEST("Маша", 1);
+    TEST("Уля", 2);
+    TEST("1", 4);
+    TEST("~", 5);
+    TEST("ѷ", 6);
+    TEST("Έ", 7);
+    TEST("ｷ", 8);
+    TEST("ﾈ", 9);
+    TEST("𣝷", 10);
+    TEST("𨢈", 11);
+    TEST("𤰖", 12);
+    TEST("𝌒", 13);
+    TEST("Сергей", 0);
+    TEST("Сергеы", 0);
+    TEST("сергеЫ", 0);
     return 0;
 }


### PR DESCRIPTION
Masked a character with a bit at 0x0F0000 position with MAX_4BYTE_RUNE (0x10FFFF) that bit was missing.
Such as 𤰖 (0x024C16).