### PR TITLE
Initial support of CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Configure
+        run: |
+          cmake -S . -Bcmake-build
+
+      - name: Build
+        run: cmake --build cmake-build
+
+      - name: Test
+        run: cmake --build cmake-build --target check


### PR DESCRIPTION
Hello,

This PR introduces initial GitHub Actions support by adding Configure, Build and Test steps. Right now it uses only Linux. I'll add macOS and Windows support a bit later.

To see how it works now refer to: https://github.com/sergeyklay/re2c/runs/1175055832?check_suite_focus=true