### PR TITLE
Add macOS support for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,54 @@ on:
 jobs:
   build-and-test:
 
-    runs-on: ubuntu-latest
+    name: ${{ matrix.toolchain }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        toolchain:
+          - linux-gcc
+          - macos-clang
+
+        configuration:
+          - Debug
+
+        include:
+          - toolchain: linux-gcc
+            os: ubuntu-latest
+            compiler: gcc
+
+          - toolchain: macos-clang
+            os: macos-latest
+            compiler: clang
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
 
-      - name: Configure
+      - name: Setup Common Prerequisites (Linux)
+        if: startsWith(runner.os, 'Linux')
         run: |
-          cmake -S . -Bcmake-build
+          echo "::set-env name=CC::gcc"
+          echo "::set-env name=CXX::g++"
+
+      - name: Setup Common Prerequisites (macOS)
+        if: startsWith(runner.os, 'macOS')
+        run: |
+          sudo xcode-select -switch /Applications/Xcode.app
+
+          echo "::set-env name=CC::$(xcrun -f clang)"
+          echo "::set-env name=CXX::$(xcrun -f clang++)"
+          echo "::set-env name=SDKROOT::$(xcodebuild -version -sdk macosx Path)"
+          echo "::set-env name=PATH::$(dirname $(xcrun -f clang)):$PATH"
+
+      - name: Verify Toolchain Version
+        run: |
+          $CC --version
+          cmake --version
+
+      - name: Configure (${{ matrix.configuration }})
+        run: cmake -S . -Bcmake-build -DCMAKE_BUILD_TYPE=${{ matrix.configuration }}
 
       - name: Build
         run: cmake --build cmake-build


### PR DESCRIPTION
Hello,

This PR adds macOS with Apple Clang to the build matrix on GitHub Action. I'd prefer not to complicate the workflow configuration at this time until I have a complete matrix.

To see how it works now refer to: https://github.com/sergeyklay/re2c/actions/runs/282978499