### PR TITLE
Cleaned up CMakeLists.txt to use platform independent bison search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,15 +28,7 @@ option(RE2C_BUILD_LIBS "Build libraries" OFF)
 option(RE2C_BUILD_RE2GO "Build re2go executable (an alias for `re2c --lang go`)" ON)
 
 # checks for programs
-if(WIN32)
-    find_program(
-      BISON_EXECUTABLE
-      NAMES bison.exe win_bison.exe
-      PATHS C:/
-      PATH_SUFFIXES "")
-else()
-    find_package(BISON)
-endif()
+find_package(BISON)
 
 # checks for C++ compiler flags
 set(CMAKE_CXX_STANDARD 98)


### PR DESCRIPTION
This PR fixes my previous PR (#311) to use platform independent bison search.

After discussion in https://github.com/skvadrik/re2c/pull/311#discussion_r498687041, I decided to double-check this approach again and made sure that it actually works.  I don't quite understand why I wasn't able to get this to work before, maybe I didn't read the documentation carefully or missed something important. Anyway now it works, and looks clear and simple as initially.

To see how it works refer https://github.com/sergeyklay/re2c/runs/1198167217?check_suite_focus=true#step:8:16