### PR TITLE
GitHub actions improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,18 @@ jobs:
         run: |
           case ${{ runner.os }} in
             Linux*)
-              echo "::set-env name=CC::gcc"
-              echo "::set-env name=CXX::g++"
+              echo "CC=gcc" >> $GITHUB_ENV
+              echo "CXX=g++" >> $GITHUB_ENV
               ;;
             macOS*)
               sudo xcode-select -switch /Applications/Xcode.app
-              echo "::set-env name=CC::$(xcrun -f clang)"
-              echo "::set-env name=CXX::$(xcrun -f clang++)"
-              echo "::set-env name=SDKROOT::$(xcodebuild -version -sdk macosx Path)"
-              echo "::set-env name=PATH::$(dirname $(xcrun -f clang)):$PATH"
+
+              echo "CC=$(xcrun -f clang)" >> $GITHUB_ENV
+              echo "CXX=$(xcrun -f clang++)" >> $GITHUB_ENV
+              echo "SDKROOT=$(xcodebuild -version -sdk macosx Path)" >> $GITHUB_ENV
+
+              echo "$(xcodebuild -version -sdk macosx Path)" >> $GITHUB_PATH
+
               ;;
             Windows*)
               choco install --no-progress -y winflexbison3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,27 +16,101 @@ jobs:
 
     strategy:
       matrix:
-        toolchain:
-          - linux-gcc
-          - macos-clang
-          - windows-msvc
-
-        build-type:
-          - Debug
-          - Release
 
         include:
+          # Linux
           - toolchain: linux-gcc
             os: ubuntu-latest
-            compiler: gcc
+            build-type: Debug
+            build-dir: .build
+            common-flags: '-O2 -fsanitize=undefined'
+            skeleton: ${{ false }}
+
+          - toolchain: linux-gcc
+            os: ubuntu-latest
+            build-type: Debug
+            build-dir: .build
+            common-flags: '-O2 -fsanitize=address'
+            skeleton: ${{ false }}
+
+          - toolchain: linux-gcc
+            os: ubuntu-latest
+            build-type: Debug
+            build-dir: .build
+            common-flags: -O2
+            skeleton: ${{ false }}
+
+          - toolchain: linux-gcc
+            os: ubuntu-latest
+            build-type: Debug
+            build-dir: .
+            common-flags: -O2
+            skeleton: ${{ false }}
+
+          - toolchain: linux-gcc
+            os: ubuntu-latest
+            build-type: Debug
+            build-dir: .build
+            common-flags: -O2
+            skeleton: ${{ true }}
+
+          - toolchain: linux-gcc
+            os: ubuntu-latest
+            build-type: Release
+            build-dir: .build
+            common-flags: ${{ null }}
+            skeleton: ${{ false }}
+
+          # macOS
+          - toolchain: macos-clang
+            os: macos-latest
+            build-type: Debug
+            build-dir: .build
+            common-flags: -O2
+            skeleton: ${{ false }}
 
           - toolchain: macos-clang
             os: macos-latest
-            compiler: clang
+            build-type: Debug
+            build-dir: .build
+            common-flags: -O2
+            skeleton: ${{ true }}
+
+          - toolchain: macos-clang
+            os: macos-latest
+            build-type: Debug
+            build-dir: .
+            common-flags: -O2
+            skeleton: ${{ false }}
+
+          - toolchain: macos-clang
+            os: macos-latest
+            build-type: Release
+            build-dir: .build
+            common-flags: ${{ null }}
+            skeleton: ${{ false }}
+
+          # Windows
+          - toolchain: windows-msvc
+            os: windows-latest
+            build-type: Debug
+            build-dir: .build
+            common-flags: ${{ null }}
+            skeleton: ${{ false }}
 
           - toolchain: windows-msvc
-            os: windows-2019
-            compiler: msvc
+            os: windows-latest
+            build-type: Debug
+            build-dir: .
+            common-flags: ${{ null }}
+            skeleton: ${{ false }}
+
+          - toolchain: windows-msvc
+            os: windows-latest
+            build-type: Release
+            build-dir: .build
+            common-flags: ${{ null }}
+            skeleton: ${{ false }}
 
     steps:
       - name: Checkout Code
@@ -67,36 +141,46 @@ jobs:
               echo "SDKROOT=$(xcodebuild -version -sdk macosx Path)" >> $GITHUB_ENV
 
               echo "$(xcodebuild -version -sdk macosx Path)" >> $GITHUB_PATH
-
               ;;
             Windows*)
               choco install --no-progress -y winflexbison3
               ;;
           esac
 
-      - name: Configure (${{ matrix.build-type }})
+      - name: Configure Using Flags '${{ matrix.common-flags}}'
         run: |
           case ${{ runner.os }} in
             Windows*)
-              cmake -S . -B cmake-build \
+              cmake -S . \
+                -B ${{ matrix.build-dir }} \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
                 -G "Visual Studio 16 2019" \
                 -A x64
               ;;
             *)
-              cmake -S . -B cmake-build \
+              cmake -S . \
+                -B ${{ matrix.build-dir }} \
+                -DCMAKE_C_FLAGS="${{ matrix.common-flags }}" \
+                -DCMAKE_CXX_FLAGS="${{ matrix.common-flags }}" \
+                -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.common-flags }}" \
+                -DCMAKE_SHARED_LINKER_FLAGS="${{ matrix.common-flags }}" \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
               ;;
           esac
 
       - name: Build
-        run: cmake --build cmake-build --config ${{ matrix.build-type }}
+        run: cmake --build ${{ matrix.build-dir }} --config ${{ matrix.build-type }}
 
       - name: Minimal Load Test (Windows)
         if: startsWith(runner.os, 'Windows')
-        working-directory: cmake-build\${{ matrix.build-type }}
+        working-directory: ${{ matrix.build-dir }}\${{ matrix.build-type }}
         run: ./re2c.exe --version
 
-      - name: Test
-        if: startsWith(runner.os, 'Windows') == false
-        run: cmake --build cmake-build --target check
+      - name: Standard Tests
+        if: startsWith(runner.os, 'Windows') == false &&  matrix.skeleton == false
+        run: cmake --build ${{ matrix.build-dir }} --target check
+
+      - name: Skeleton Validation
+        if: startsWith(runner.os, 'Windows') == false &&  matrix.skeleton == true
+        working-directory: ${{ matrix.build-dir }}
+        run: ./run_tests.sh --skeleton

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,42 +23,50 @@ jobs:
             os: ubuntu-latest
             build-type: Debug
             build-dir: .build
-            common-flags: '-O2 -fsanitize=undefined'
+            # Undefined Behavior Sanitizer (ubsan)
+            ld-flags: '-fsanitize=undefined'
+            cxx-flags: '-O2 -fsanitize=undefined'
             skeleton: ${{ false }}
 
           - toolchain: linux-gcc
             os: ubuntu-latest
             build-type: Debug
             build-dir: .build
-            common-flags: '-O2 -fsanitize=address'
+            # Address Sanitizer (asan)
+            ld-flags: '-fsanitize=address'
+            cxx-flags: '-O2 -fsanitize=address'
             skeleton: ${{ false }}
 
           - toolchain: linux-gcc
             os: ubuntu-latest
             build-type: Debug
             build-dir: .build
-            common-flags: -O2
+            ld-flags: ${{ null }}
+            cxx-flags: -O2
             skeleton: ${{ false }}
 
           - toolchain: linux-gcc
             os: ubuntu-latest
             build-type: Debug
             build-dir: .
-            common-flags: -O2
+            ld-flags: ${{ null }}
+            cxx-flags: -O2
             skeleton: ${{ false }}
 
           - toolchain: linux-gcc
             os: ubuntu-latest
             build-type: Debug
             build-dir: .build
-            common-flags: -O2
+            ld-flags: ${{ null }}
+            cxx-flags: -O2
             skeleton: ${{ true }}
 
           - toolchain: linux-gcc
             os: ubuntu-latest
             build-type: Release
             build-dir: .build
-            common-flags: ${{ null }}
+            ld-flags: ${{ null }}
+            cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
           # macOS
@@ -66,28 +74,32 @@ jobs:
             os: macos-latest
             build-type: Debug
             build-dir: .build
-            common-flags: -O2
+            ld-flags: ${{ null }}
+            cxx-flags: -O2
             skeleton: ${{ false }}
 
           - toolchain: macos-clang
             os: macos-latest
             build-type: Debug
             build-dir: .build
-            common-flags: -O2
+            ld-flags: ${{ null }}
+            cxx-flags: -O2
             skeleton: ${{ true }}
 
           - toolchain: macos-clang
             os: macos-latest
             build-type: Debug
             build-dir: .
-            common-flags: -O2
+            ld-flags: ${{ null }}
+            cxx-flags: -O2
             skeleton: ${{ false }}
 
           - toolchain: macos-clang
             os: macos-latest
             build-type: Release
             build-dir: .build
-            common-flags: ${{ null }}
+            ld-flags: ${{ null }}
+            cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
           # Windows
@@ -95,21 +107,24 @@ jobs:
             os: windows-latest
             build-type: Debug
             build-dir: .build
-            common-flags: ${{ null }}
+            ld-flags: ${{ null }}
+            cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
           - toolchain: windows-msvc
             os: windows-latest
             build-type: Debug
             build-dir: .
-            common-flags: ${{ null }}
+            ld-flags: ${{ null }}
+            cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
           - toolchain: windows-msvc
             os: windows-latest
             build-type: Release
             build-dir: .build
-            common-flags: ${{ null }}
+            ld-flags: ${{ null }}
+            cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
     steps:
@@ -147,7 +162,7 @@ jobs:
               ;;
           esac
 
-      - name: Configure Using Flags '${{ matrix.common-flags}}'
+      - name: Configure
         run: |
           case ${{ runner.os }} in
             Windows*)
@@ -158,13 +173,22 @@ jobs:
                 -A x64
               ;;
             *)
-              cmake -S . \
-                -B ${{ matrix.build-dir }} \
-                -DCMAKE_C_FLAGS="${{ matrix.common-flags }}" \
-                -DCMAKE_CXX_FLAGS="${{ matrix.common-flags }}" \
-                -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.common-flags }}" \
-                -DCMAKE_SHARED_LINKER_FLAGS="${{ matrix.common-flags }}" \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+              # Common CMake arguments
+              args=( -S . -B ${{ matrix.build-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} )
+
+              # CFLAGS, CXXFLAGS
+              [[ ! -z '${{ matrix.cxx-flags }}' ]] && \
+                args+=( -DCMAKE_C_FLAGS="${{ matrix.cxx-flags }}" -DCMAKE_CXX_FLAGS="${{ matrix.cxx-flags }}" )
+
+              # LDFLAGS
+              [[ ! -z '${{ matrix.ld-flags }}' ]] && \
+                args+=( -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.ld-flags }}" -DCMAKE_SHARED_LINKER_FLAGS="${{ matrix.ld-flags }}" )
+
+              # Debug
+              echo "cmake ${args[@]}"
+
+              # Run
+              cmake "${args[@]}"
               ;;
           esac
 

--- a/cmake/Re2cCompilerFlags.cmake
+++ b/cmake/Re2cCompilerFlags.cmake
@@ -59,4 +59,7 @@ foreach(_lang IN LISTS _languages)
     endif()
 endforeach()
 
+message(STATUS "Linker flags to be used to create executables: ${CMAKE_EXE_LINKER_FLAGS}")
+message(STATUS "Linker flags to be used to create shared libraries: ${CMAKE_SHARED_LINKER_FLAGS}")
+
 unset(_languages)


### PR DESCRIPTION
Hello,

This PR amends the build matrix on GitHub Actions. The full used matrix is:

|  OS | Build Type  | Build Dir  | Common Flags | Skeleton |
| :---  |  ---  | --- | --- | --- |
| Linux | `Debug` | out-of-tree | `-O2 -fsanitize=undefined` | false |
| Linux | `Debug` | out-of-tree | `-O2 -fsanitize=address` | false |
| Linux | `Debug` | out-of-tree | `-O2` | false |
| Linux | `Debug` | in-tree | `-O2` | false |
| Linux | `Debug` | out-of-tree | `-O2` | **true** |
| Linux | `Release` | out-of-tree | — | false |
| macOs | `Debug` | out-of-tree | `-O2` | false  |
| macOs | `Debug` | out-of-tree | `-O2` | **true** |
| macOs | `Debug` |  in-tree | `-O2` | false  |
| macOs | `Release` | out-of-tree | — | false  |
| Windows | `Debug` | out-of-tree | — | false |
| Windows | `Debug` | in-tree | — | false  |
| Windows | `Release` | out-of-tree | — | false |

I removed `-g` for `Debug` configurations as it is used by default (see discussion in https://github.com/skvadrik/re2c/pull/316). There are still some things I need to port from Travis' configuration, but I'd like to do this in a separated PR. Let me know if I should amend this matrix.

Also I replaced deprecated `set-env` and `add-path` commands (see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ and [CVE-2020-15228](https://github.com/advisories/GHSA-mfwh-5m23-j46w)).