### PR TITLE
Added Asan and Ubsan CMake profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,27 +21,24 @@ jobs:
           # Linux
           - toolchain: linux-gcc
             os: ubuntu-latest
-            build-type: Debug
+            # Undefined Behavior Sanitizer (cmake -DCMAKE_BUILD_TYPE=Ubsan)
+            build-type: Ubsan
             build-dir: .build
-            # Undefined Behavior Sanitizer (ubsan)
-            ld-flags: '-fsanitize=undefined'
-            cxx-flags: '-O2 -fsanitize=undefined'
+            cxx-flags: '-O2'
+            skeleton: ${{ false }}
+
+          - toolchain: linux-gcc
+            os: ubuntu-latest
+            # Address Sanitizer (cmake -DCMAKE_BUILD_TYPE=Asan)
+            build-type: Asan
+            build-dir: .build
+            cxx-flags: '-O2'
             skeleton: ${{ false }}
 
           - toolchain: linux-gcc
             os: ubuntu-latest
             build-type: Debug
             build-dir: .build
-            # Address Sanitizer (asan)
-            ld-flags: '-fsanitize=address'
-            cxx-flags: '-O2 -fsanitize=address'
-            skeleton: ${{ false }}
-
-          - toolchain: linux-gcc
-            os: ubuntu-latest
-            build-type: Debug
-            build-dir: .build
-            ld-flags: ${{ null }}
             cxx-flags: -O2
             skeleton: ${{ false }}
 
@@ -49,7 +46,6 @@ jobs:
             os: ubuntu-latest
             build-type: Debug
             build-dir: .
-            ld-flags: ${{ null }}
             cxx-flags: -O2
             skeleton: ${{ false }}
 
@@ -57,7 +53,6 @@ jobs:
             os: ubuntu-latest
             build-type: Debug
             build-dir: .build
-            ld-flags: ${{ null }}
             cxx-flags: -O2
             skeleton: ${{ true }}
 
@@ -65,7 +60,6 @@ jobs:
             os: ubuntu-latest
             build-type: Release
             build-dir: .build
-            ld-flags: ${{ null }}
             cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
@@ -74,7 +68,6 @@ jobs:
             os: macos-latest
             build-type: Debug
             build-dir: .build
-            ld-flags: ${{ null }}
             cxx-flags: -O2
             skeleton: ${{ false }}
 
@@ -82,7 +75,6 @@ jobs:
             os: macos-latest
             build-type: Debug
             build-dir: .build
-            ld-flags: ${{ null }}
             cxx-flags: -O2
             skeleton: ${{ true }}
 
@@ -90,7 +82,6 @@ jobs:
             os: macos-latest
             build-type: Debug
             build-dir: .
-            ld-flags: ${{ null }}
             cxx-flags: -O2
             skeleton: ${{ false }}
 
@@ -98,7 +89,6 @@ jobs:
             os: macos-latest
             build-type: Release
             build-dir: .build
-            ld-flags: ${{ null }}
             cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
@@ -107,7 +97,6 @@ jobs:
             os: windows-latest
             build-type: Debug
             build-dir: .build
-            ld-flags: ${{ null }}
             cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
@@ -115,7 +104,6 @@ jobs:
             os: windows-latest
             build-type: Debug
             build-dir: .
-            ld-flags: ${{ null }}
             cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
@@ -123,7 +111,6 @@ jobs:
             os: windows-latest
             build-type: Release
             build-dir: .build
-            ld-flags: ${{ null }}
             cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
@@ -179,10 +166,6 @@ jobs:
               # CFLAGS, CXXFLAGS
               [[ ! -z '${{ matrix.cxx-flags }}' ]] && \
                 args+=( -DCMAKE_C_FLAGS="${{ matrix.cxx-flags }}" -DCMAKE_CXX_FLAGS="${{ matrix.cxx-flags }}" )
-
-              # LDFLAGS
-              [[ ! -z '${{ matrix.ld-flags }}' ]] && \
-                args+=( -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.ld-flags }}" -DCMAKE_SHARED_LINKER_FLAGS="${{ matrix.ld-flags }}" )
 
               # Debug
               echo "cmake ${args[@]}"

--- a/build/__cmakebuild_asan.sh
+++ b/build/__cmakebuild_asan.sh
@@ -6,10 +6,8 @@ mkdir $builddir
 
 cd $builddir
 cmake .. \
-    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_BUILD_TYPE=Asan \
     -DRE2C_BUILD_LIBS=yes \
-    -DCMAKE_CXX_FLAGS="-O2 -fsanitize=address" \
-    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
-    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address" \
+    -DCMAKE_CXX_FLAGS="-O2" \
     && cmake --build . -j$(nproc)
 cd ..

--- a/build/__cmakebuild_ubsan.sh
+++ b/build/__cmakebuild_ubsan.sh
@@ -6,10 +6,8 @@ mkdir $builddir
 
 cd $builddir
 cmake .. \
-    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_BUILD_TYPE=Ubsan \
     -DRE2C_BUILD_LIBS=yes \
-    -DCMAKE_CXX_FLAGS="-O2 -fsanitize=undefined" \
-    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=undefined" \
-    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=undefined" \
+    -DCMAKE_CXX_FLAGS="-O2" \
     && cmake --build . -j$(nproc)
 cd ..

--- a/cmake/Re2cBuildType.cmake
+++ b/cmake/Re2cBuildType.cmake
@@ -1,14 +1,98 @@
-set(_allowed_build_types Debug Release RelWithDebInfo MinSizeRel)
+# CMAKE_BUILD_TYPE is not used by multi-configuration generators.
+# Thus, we need to check this first.
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 
-# 1. The default value for CMAKE_BUILD_TYPE is an empty string.
-# 2. User can set CMAKE_BUILD_TYPE to any value at the cmake command line.
-#
-# Therefore, we check both cases, and make sure that we are dealing with
-# a known build type (if any).
-#
-# For more see discussion at https://github.com/skvadrik/re2c/pull/316
-if(CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE IN_LIST _allowed_build_types)
-    message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}")
+if(NOT isMultiConfig) # Makefiles, Ninja, ...
+    set(_allowed_build_types Asan Ubsan Debug Release RelWithDebInfo MinSizeRel)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${_allowed_build_types}")
+
+    # - The default value for CMAKE_BUILD_TYPE is an empty string
+    # - User can set CMAKE_BUILD_TYPE to any value at the cmake command line
+    #
+    # Therefore, we check both cases, and make sure that we are dealing with
+    # a known build type (if any).
+    #
+    # For more see discussion at https://github.com/skvadrik/re2c/pull/316
+    if(CMAKE_BUILD_TYPE AND NOT CMAKE_BUILD_TYPE IN_LIST _allowed_build_types)
+        message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}")
+    endif()
+
+    unset(_allowed_build_types)
+elseif(NOT MULTICONFIG_DONE) # Xcode, Visual Studio, ...
+    set(MULTICONFIG_DONE TRUE)
+    if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        list(APPEND CMAKE_CONFIGURATION_TYPES Asan Ubsan)
+
+        # This is needed because user can set CMAKE_CONFIGURATION_TYPES
+        # at the cmake command line
+        list(REMOVE_DUPLICATES CMAKE_CONFIGURATION_TYPES)
+
+        set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES}" CACHE STRING
+            "Semicolon separated list of supported configuration types." FORCE)
+    endif()
 endif()
 
-unset(_allowed_build_types)
+# Notes for Windows with Visual Studio:
+#
+# - Address Sanitizer (Asan) currently is under experimental stage
+# - Undefined Behavior Sanitizer (Ubsan) is not supported at this time
+#
+# Therefore, we have disabled support for these build types now, but
+# this support may be enabled in the future.
+#
+# Notes about '-fno-omit-frame-pointer' flag:
+#
+# Frame pointer omission does make debugging significantly harder. Local
+# vars are harder to locate and stack traces are much harder to reconstruct
+# without a frame pointer to help out. Also, accessing parameters can get more
+# expensive since they are far away from the top of the stack and may require
+# more expensive addressing modes.
+#
+# The '-fno-omit-frame-pointer' option direct the compiler to generate code
+# that maintains and uses stack frame pointer for all functions so that a
+# debugger can still produce a stack backtrace even with optimizations flags
+# (eg '-O1', '-O2', etc).
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # Setup Asan flags
+    set(CMAKE_C_FLAGS_ASAN
+        "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+        "Flags used by the C compiler for Asan build type or configuration." FORCE)
+
+    set(CMAKE_CXX_FLAGS_ASAN
+        "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+        "Flags used by the C++ compiler for Asan build type or configuration." FORCE)
+
+    set(CMAKE_EXE_LINKER_FLAGS_ASAN
+        "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address" CACHE STRING
+        "Linker flags to be used to create executables for Asan build type." FORCE)
+
+    set(CMAKE_SHARED_LINKER_FLAGS_ASAN
+        "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address" CACHE STRING
+        "Linker flags to be used to create shared libraries for Asan build type." FORCE)
+
+    set(CMAKE_STATIC_LINKER_FLAGS_ASAN
+        "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fsanitize=address" CACHE STRING
+        "Linker flags to be used to create static libraries for Asan build type." FORCE)
+
+    # Setup Ubsan flags
+    set(CMAKE_C_FLAGS_UBSAN
+        "${CMAKE_C_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer" CACHE STRING
+        "Flags used by the C compiler for Ubsan build type or configuration." FORCE)
+
+    set(CMAKE_CXX_FLAGS_UBSAN
+        "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=undefined -fno-omit-frame-pointer" CACHE STRING
+        "Flags used by the C++ compiler for Ubsan build type or configuration." FORCE)
+
+    set(CMAKE_EXE_LINKER_FLAGS_UBSAN
+        "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=undefined" CACHE STRING
+        "Linker flags to be used to create executables for Ubsan build type." FORCE)
+
+    set(CMAKE_SHARED_LINKER_FLAGS_UBSAN
+        "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=undefined" CACHE STRING
+        "Linker flags to be used to create shared libraries for Ubsan build type." FORCE)
+
+    set(CMAKE_STATIC_LINKER_FLAGS_UBSAN
+        "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fsanitize=undefined" CACHE STRING
+        "Linker flags to be used to create static libraries for Ubsan build type." FORCE)
+endif()
+

--- a/cmake/Re2cCompilerFlags.cmake
+++ b/cmake/Re2cCompilerFlags.cmake
@@ -47,19 +47,18 @@ try_cxxflag("-Weverything"
 
 try_cxxflag("-fdiagnostics-color=always")
 
-# Verify compiler flags
-get_property(_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
-
-foreach(_lang IN LISTS _languages)
-    message(STATUS "Common compiler flags for ${_lang}: ${CMAKE_${_lang}_FLAGS}")
-    if (CMAKE_BUILD_TYPE)
-        string(TOUPPER ${CMAKE_BUILD_TYPE} _config)
-        message(STATUS "${CMAKE_BUILD_TYPE} compiler flags for ${_lang}: ${CMAKE_${_lang}_FLAGS_${_config}}")
-        unset(_config)
-    endif()
-endforeach()
-
-message(STATUS "Linker flags to be used to create executables: ${CMAKE_EXE_LINKER_FLAGS}")
-message(STATUS "Linker flags to be used to create shared libraries: ${CMAKE_SHARED_LINKER_FLAGS}")
-
-unset(_languages)
+# Print compiler and linker flags
+message(STATUS "C compiler flags: ${CMAKE_C_FLAGS}")
+message(STATUS "C++ compiler flags: ${CMAKE_CXX_FLAGS}")
+message(STATUS "Linker flags for executables: ${CMAKE_EXE_LINKER_FLAGS}")
+message(STATUS "Linker flags for shared libs: ${CMAKE_SHARED_LINKER_FLAGS}")
+message(STATUS "Linker flags for static libs: ${CMAKE_STATIC_LINKER_FLAGS}")
+if (CMAKE_BUILD_TYPE)
+    string(TOUPPER ${CMAKE_BUILD_TYPE} _type)
+    message(STATUS "${CMAKE_BUILD_TYPE} C compiler flags: ${CMAKE_C_FLAGS_${_type}}")
+    message(STATUS "${CMAKE_BUILD_TYPE} C++ compiler flags: ${CMAKE_CXX_FLAGS_${_type}}")
+    message(STATUS "${CMAKE_BUILD_TYPE} linker flags for executables: ${CMAKE_EXE_LINKER_FLAGS_${_type}}")
+    message(STATUS "${CMAKE_BUILD_TYPE} linker flags for shared libs: ${CMAKE_SHARED_LINKER_FLAGS_${_type}}")
+    message(STATUS "${CMAKE_BUILD_TYPE} linker flags for static libs: ${CMAKE_STATIC_LINKER_FLAGS_${_type}}")
+    unset(_type)
+endif()


### PR DESCRIPTION
Hello,

This PR adds support of Asan and Ubsan build types for CMake. I prefer this option since it expresses the intent (run sanitizers) rather than modifies a number of flags. This also simplifies a bit build matrix on GitHub workflow.

Usage:
```bash
$ cmake \
    -DCMAKE_BUILD_TYPE=Asan \
    ...
    ...
```

Old school fans can still use the way with explicit passing of flags:
```bash
$ cmake \
    -DCMAKE_C_FLAGS="-g -fsanitize=address -fno-omit-frame-pointer" \
    -DCMAKE_CXX_FLAGS="-g -fsanitize=address -fno-omit-frame-pointer" \
    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address" \
    ...
    ...
```

Note, I added `-fno-omit-frame-pointer` to Asan build type and do not added `-O2` (it is added by workflow matrix). Let me know if you'd like to modify Asan/Ubsan build types by adding/removing flags.