### PR TITLE
Add minimal install test on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ defaults:
 
 jobs:
   build-and-test:
-
-    name: "${{ matrix.build-type }}: ${{ matrix.toolchain }}"
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -19,7 +18,7 @@ jobs:
 
         include:
           # Linux
-          - toolchain: linux-gcc
+          - name: linux-gcc-ubsan-ootree
             os: ubuntu-latest
             # Undefined Behavior Sanitizer (cmake -DCMAKE_BUILD_TYPE=Ubsan)
             build-type: Ubsan
@@ -27,7 +26,7 @@ jobs:
             cxx-flags: '-O2'
             skeleton: ${{ false }}
 
-          - toolchain: linux-gcc
+          - name: linux-gcc-asan-ootree
             os: ubuntu-latest
             # Address Sanitizer (cmake -DCMAKE_BUILD_TYPE=Asan)
             build-type: Asan
@@ -35,28 +34,28 @@ jobs:
             cxx-flags: '-O2'
             skeleton: ${{ false }}
 
-          - toolchain: linux-gcc
+          - name: linux-gcc-debug-ootree
             os: ubuntu-latest
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
             skeleton: ${{ false }}
 
-          - toolchain: linux-gcc
+          - name: linux-gcc-debug-intree
             os: ubuntu-latest
             build-type: Debug
             build-dir: .
             cxx-flags: -O2
             skeleton: ${{ false }}
 
-          - toolchain: linux-gcc
+          - name: linux-gcc-debug-ootree-skeleton
             os: ubuntu-latest
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
             skeleton: ${{ true }}
 
-          - toolchain: linux-gcc
+          - name: linux-gcc-release-ootree
             os: ubuntu-latest
             build-type: Release
             build-dir: .build
@@ -64,28 +63,28 @@ jobs:
             skeleton: ${{ false }}
 
           # macOS
-          - toolchain: macos-clang
+          - name: macos-clang-debug-ootree
             os: macos-latest
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
             skeleton: ${{ false }}
 
-          - toolchain: macos-clang
+          - name: macos-clang-debug-ootree-skeleton
             os: macos-latest
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
             skeleton: ${{ true }}
 
-          - toolchain: macos-clang
+          - name: macos-clang-debug-intree
             os: macos-latest
             build-type: Debug
             build-dir: .
             cxx-flags: -O2
             skeleton: ${{ false }}
 
-          - toolchain: macos-clang
+          - name: macos-clang-release-ootree
             os: macos-latest
             build-type: Release
             build-dir: .build
@@ -93,21 +92,21 @@ jobs:
             skeleton: ${{ false }}
 
           # Windows
-          - toolchain: windows-msvc
+          - name: windows-msvc-debug-ootree
             os: windows-latest
             build-type: Debug
             build-dir: .build
             cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
-          - toolchain: windows-msvc
+          - name: windows-msvc-debug-intree
             os: windows-latest
             build-type: Debug
             build-dir: .
             cxx-flags: ${{ null }}
             skeleton: ${{ false }}
 
-          - toolchain: windows-msvc
+          - name: windows-msvc-release-ootree
             os: windows-latest
             build-type: Release
             build-dir: .build
@@ -151,10 +150,12 @@ jobs:
 
       - name: Configure
         run: |
+          INSTALL_PREFIX="$(pwd)/install"
           case ${{ runner.os }} in
             Windows*)
               cmake -S . \
                 -B ${{ matrix.build-dir }} \
+                -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
                 -G "Visual Studio 16 2019" \
                 -A x64
@@ -162,6 +163,7 @@ jobs:
             *)
               # Common CMake arguments
               args=( -S . -B ${{ matrix.build-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} )
+              args+=( -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" )
 
               # CFLAGS, CXXFLAGS
               [[ ! -z '${{ matrix.cxx-flags }}' ]] && \
@@ -178,16 +180,22 @@ jobs:
       - name: Build
         run: cmake --build ${{ matrix.build-dir }} --config ${{ matrix.build-type }}
 
-      - name: Minimal Load Test (Windows)
-        if: startsWith(runner.os, 'Windows')
-        working-directory: ${{ matrix.build-dir }}\${{ matrix.build-type }}
-        run: ./re2c.exe --version
-
       - name: Standard Tests
         if: startsWith(runner.os, 'Windows') == false &&  matrix.skeleton == false
         run: cmake --build ${{ matrix.build-dir }} --target check
 
       - name: Skeleton Validation
-        if: startsWith(runner.os, 'Windows') == false &&  matrix.skeleton == true
+        if: startsWith(runner.os, 'Windows') == false && matrix.skeleton == true
         working-directory: ${{ matrix.build-dir }}
         run: ./run_tests.sh --skeleton
+
+      - name: Install
+        run: |
+          cmake --build ${{ matrix.build-dir }} --config ${{ matrix.build-type }} --target install
+          echo -e "Install tree:\n$(find install | sed 's/^/-- /')"
+
+      - name: Minimal Install Test
+        working-directory: ./install/bin
+        run: |
+          ./re2c --version
+          ./re2go --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,15 +287,13 @@ add_custom_target(docs DEPENDS "${re2c_docs}")
 # install and test targets are enabled only if re2c is the root project
 if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     # install
-    if(UNIX)
-        install(TARGETS re2c RUNTIME DESTINATION bin)
-        install(FILES "${re2c_manpage_c}" DESTINATION "share/man/man1")
-        if(RE2C_BUILD_RE2GO)
-            install(TARGETS re2go RUNTIME DESTINATION bin)
-            install(FILES "${re2c_manpage_go}" DESTINATION "share/man/man1")
-        endif()
-        install(FILES include/unicode_categories.re DESTINATION "${RE2C_STDLIB_DIR}")
+    install(TARGETS re2c RUNTIME DESTINATION bin)
+    install(FILES "${re2c_manpage_c}" DESTINATION "share/man/man1")
+    if(RE2C_BUILD_RE2GO)
+        install(TARGETS re2go RUNTIME DESTINATION bin)
+        install(FILES "${re2c_manpage_go}" DESTINATION "share/man/man1")
     endif()
+    install(FILES include/unicode_categories.re DESTINATION "${RE2C_STDLIB_DIR}")
 
     # rebuild all re2c sources using newly built re2c
     add_custom_target(bootstrap


### PR DESCRIPTION
This PR adds ability to install re2c as well as re2go on GitHub Actions.

Another notable changes are:

#### Install on Windows

I've started work to enable `install` targets for Windows. There is no ability to install libs yet, but the main binaries can be already installed.

#### Minimal Install Test

Renamed `Minimal Load Test (Windows)` job to more generic  `Minimal Install Test`. We'll amend this job in the future. But right now it tests that after installation the necessary binaries are in the expected place and you can run them (on Windows too).

#### Jobs Naming

Make the names of the builds more descriptive as discussed here:  https://github.com/skvadrik/re2c/pull/317#issuecomment-706685657