### PR TITLE
Fixed '-Wunreachable-code' warning

### DIFF
--- a/src/parse/lex.re
+++ b/src/parse/lex.re
@@ -425,7 +425,6 @@ scan:
 
     * {
         msg.fatal(tok_loc(), "unexpected character: '%c'", *tok);
-        goto scan;
     }
 */
 }


### PR DESCRIPTION
Hello,

This code will never be executed (was found by Clang):

```text
../src/parse/lex.re:428:9: warning: code will never be executed
      [-Wunreachable-code]
        goto scan;
        ^~~~~~~~~
```