### PR TITLE
Add the ability to generate manpage and documentation for BSD systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,14 @@ ac_subst(PACKAGE_VERSION "${PROJECT_VERSION}")
 
 option(RE2C_REBUILD_LEXERS "Regenerate lexers" OFF)
 if(RE2C_REBUILD_LEXERS AND NOT RE2C_FOR_BUILD)
-    message(FATAL_ERROR "need RE2C_FOR_BUILD for RE2C_REBUILD_LEXERS")
+    message(FATAL_ERROR "option RE2C_FOR_BUILD is required for RE2C_REBUILD_LEXERS")
 endif()
 
 option(RE2C_REBUILD_DOCS "Regenerate manpage" OFF)
 if(RE2C_REBUILD_DOCS)
     find_program(RST2MAN NAMES rst2man rst2man.py)
     if(NOT RST2MAN)
-        message(FATAL_ERROR "need rst2man or rst2man.py for RE2C_REBUILD_DOCS")
+        message(FATAL_ERROR "rst2man (or rst2man.py) program is required for RE2C_REBUILD_DOCS")
     endif()
 
     # Windows does not have a native 'man' and 'sed' commands.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,20 @@ if(RE2C_REBUILD_DOCS)
     if(NOT RST2MAN)
         message(FATAL_ERROR "need rst2man or rst2man.py for RE2C_REBUILD_DOCS")
     endif()
+
+    # Windows does not have a native 'man' and 'sed' commands.
+    # Therefore, we are looking for the Cygwin versions of 'man' and 'sed'.
+    if (WIN32)
+        find_program(MAN_EXECUTABLE man)
+        if(NOT MAN_EXECUTABLE)
+            message(FATAL_ERROR "man program is required for RE2C_REBUILD_DOCS")
+        endif()
+
+        find_program(SED_EXECUTABLE sed)
+        if(NOT SED_EXECUTABLE)
+            message(FATAL_ERROR "sed program is required for RE2C_REBUILD_DOCS")
+        endif()
+    endif()
 endif()
 
 option(RE2C_BUILD_LIBS "Build libraries" OFF)

--- a/build/gen_help.sh
+++ b/build/gen_help.sh
@@ -1,13 +1,29 @@
+#!/usr/bin/env sh
 
-> "$2"
-echo "extern const char *help;" >> "$2"
-echo "const char *help =" >> "$2"
-MANPAGER=cat MANWIDTH=100 man "$1" \
-    | tail -n +6 \
-    | head -n -1 \
-    | sed -E -e 's/\x1b\x5b[0-9]+m//g' \
-    | sed 's/\\x/\\\\x/g' \
-    | sed -E 's/"/\\"/g' \
-    | sed -E 's/(.*)/"\1\\n"/' \
-    >> "$2"
-echo ";" >> "$2"
+{
+    # We can safely export the following variables unless we source this file
+    export TERM=dumb
+    export MANPAGER=cat
+    export MANWIDTH=80
+
+    echo "extern const char *help;"
+    echo "const char *help ="
+
+    # Here is how it works:
+    #
+    # 1. 'col -b' removes backspaces, 'col -x' replaces tabs with spaces
+    # 2. Drop lines from the top up to USAGE word
+    # 3. Drop two lines from the bottom
+    # 4. Escape \x by \\x
+    # 5. Escape " by \"
+    # 6. Wrap each line in double quotes " and adding a newline character \n
+    man "$1"                        \
+        | col -bx                   \
+        | grep -A 1000 USAGE        \
+        | sed '$d' | sed '$d'       \
+        | sed 's/\\x/\\\\x/g'       \
+        | sed -E 's/"/\\"/g'        \
+        | sed -E 's/(.*)/"\1\\n"/'
+
+    echo ";"
+} > "$2"

--- a/cmake/Re2cGenDocs.cmake
+++ b/cmake/Re2cGenDocs.cmake
@@ -4,7 +4,7 @@ function(re2c_gen_manpage source target bootstrap lang)
         add_custom_command(
             OUTPUT "${target}"
             COMMAND "${re2c_splitman}" "${source}" "${source_l}" "${lang}"
-            COMMAND "${RST2MAN}" --tab-width=4 "${source_l}" > "${target}"
+            COMMAND "${RST2MAN}" --tab-width=4 "${source_l}" "${target}"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${target}" "${bootstrap}"
             DEPENDS
                 "${source}"
@@ -25,7 +25,7 @@ function(re2c_gen_help source target bootstrap)
     if(RE2C_REBUILD_DOCS)
         add_custom_command(
             OUTPUT "${target}"
-            COMMAND "${RST2MAN}" "${source}" > "${target}.1"
+            COMMAND "${RST2MAN}" "${source}" "${target}.1"
             COMMAND "${re2c_genhelp}" "${target}.1" "${target}"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${target}" "${bootstrap}"
             DEPENDS


### PR DESCRIPTION
**Add the ability to generate manpage and documentation for BSD systems**

- Stripping headers may not work as expected, as man output differs on different systems. This should work now.
- Simplified output parsing procedure by replacing the regular expression by `TERM=dumb`.
- Stripping escape sequences.
- Added documentation about the intentions of this script.


**Check for `man` and `sed` on Windows when `RE2C_REBUILD_DOCS` is `ON`**

Windows does not have a native `man` and `sed` commands. Therefore, we are looking for the Cygwin versions of  `man` and `sed`. This doesn't add full Windows support. However, in case of the absence of the required programs, this shows error messages before the build stage.

**Rephrase error messages for `RE2C_REBUILD_DOCS=ON`**

This aims to provide a bit more clear error messages on regenerate manpage stage as well as documentation.

**Remove rst2man output redirection as it doesn't work on Windows**

There is no need for redirect output with `>` (which doesn't work on Windows) as this is how rst2man works:
```
  rst2man [options] [<source> [<destination>]]
```

---

For the discussion see: https://github.com/skvadrik/re2c/issues/325