### PR TITLE
Restructuring Configure and Build jobs on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           # Linux
           - name: linux-gcc-ubsan-ootree
             os: ubuntu-latest
-            # Undefined Behavior Sanitizer (cmake -DCMAKE_BUILD_TYPE=Ubsan)
+            generator: Unix Makefiles
             build-type: Ubsan
             build-dir: .build
             cxx-flags: '-O2'
@@ -28,7 +28,7 @@ jobs:
 
           - name: linux-gcc-asan-ootree
             os: ubuntu-latest
-            # Address Sanitizer (cmake -DCMAKE_BUILD_TYPE=Asan)
+            generator: Unix Makefiles
             build-type: Asan
             build-dir: .build
             cxx-flags: '-O2'
@@ -36,6 +36,7 @@ jobs:
 
           - name: linux-gcc-debug-ootree
             os: ubuntu-latest
+            generator: Unix Makefiles
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
@@ -43,6 +44,7 @@ jobs:
 
           - name: linux-gcc-debug-intree
             os: ubuntu-latest
+            generator: Unix Makefiles
             build-type: Debug
             build-dir: .
             cxx-flags: -O2
@@ -50,6 +52,7 @@ jobs:
 
           - name: linux-gcc-debug-ootree-skeleton
             os: ubuntu-latest
+            generator: Unix Makefiles
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
@@ -57,6 +60,7 @@ jobs:
 
           - name: linux-gcc-release-ootree
             os: ubuntu-latest
+            generator: Unix Makefiles
             build-type: Release
             build-dir: .build
             cxx-flags: ${{ null }}
@@ -65,6 +69,7 @@ jobs:
           # macOS
           - name: macos-clang-debug-ootree
             os: macos-latest
+            generator: Unix Makefiles
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
@@ -72,6 +77,7 @@ jobs:
 
           - name: macos-clang-debug-ootree-skeleton
             os: macos-latest
+            generator: Unix Makefiles
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
@@ -79,6 +85,7 @@ jobs:
 
           - name: macos-clang-debug-intree
             os: macos-latest
+            generator: Unix Makefiles
             build-type: Debug
             build-dir: .
             cxx-flags: -O2
@@ -86,6 +93,7 @@ jobs:
 
           - name: macos-clang-release-ootree
             os: macos-latest
+            generator: Unix Makefiles
             build-type: Release
             build-dir: .build
             cxx-flags: ${{ null }}
@@ -94,6 +102,7 @@ jobs:
           # Windows
           - name: windows-msvc-debug-ootree
             os: windows-latest
+            generator: Visual Studio 16 2019
             build-type: Debug
             build-dir: .build
             cxx-flags: ${{ null }}
@@ -101,6 +110,7 @@ jobs:
 
           - name: windows-msvc-debug-intree
             os: windows-latest
+            generator: Visual Studio 16 2019
             build-type: Debug
             build-dir: .
             cxx-flags: ${{ null }}
@@ -108,6 +118,7 @@ jobs:
 
           - name: windows-msvc-release-ootree
             os: windows-latest
+            generator: Visual Studio 16 2019
             build-type: Release
             build-dir: .build
             cxx-flags: ${{ null }}
@@ -148,36 +159,49 @@ jobs:
               ;;
           esac
 
-      - name: Configure
+      - name: Prepare Configure Command
+        id: configure-command
         run: |
-          INSTALL_PREFIX="$(pwd)/install"
-          case ${{ runner.os }} in
-            Windows*)
-              cmake -S . \
-                -B ${{ matrix.build-dir }} \
-                -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-                -G "Visual Studio 16 2019" \
-                -A x64
-              ;;
-            *)
-              # Common CMake arguments
-              args=( -S . -B ${{ matrix.build-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} )
-              args+=( -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" )
+          # Common CMake arguments
+          args=( -S . -B ${{ matrix.build-dir }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} )
 
-              # CFLAGS, CXXFLAGS
-              [[ ! -z '${{ matrix.cxx-flags }}' ]] && \
-                args+=( -DCMAKE_C_FLAGS="${{ matrix.cxx-flags }}" -DCMAKE_CXX_FLAGS="${{ matrix.cxx-flags }}" )
-
-              # Debug
-              echo "cmake ${args[@]}"
-
-              # Run
-              cmake "${args[@]}"
-              ;;
+          # Generator's specific stuff
+          # We don't add generator here to avoid splitting it before
+          case "${{ matrix.generator }}" in
+            'Visual Studio'*)
+              args+=( -A x64 )
+            ;;
           esac
 
-      - name: Build
+          # CFLAGS, CXXFLAGS
+          [[ ! -z '${{ matrix.cxx-flags }}' ]] && \
+            args+=( -DCMAKE_C_FLAGS="${{ matrix.cxx-flags }}" -DCMAKE_CXX_FLAGS="${{ matrix.cxx-flags }}" )
+
+          echo "::set-output name=cmake::${args[@]}"
+
+      #
+      - name: Fast Configure
+        run: |
+          # Read prepared command into an array
+          astr="${{ steps.configure-command.outputs.cmake }}"
+          args=($astr)
+
+          # Amend Build Options
+          args+=( -DCMAKE_INSTALL_PREFIX="$(pwd)/install" )
+
+          # Generator's specific stuff
+          #
+          # Notice, some generator names contains a space, this is why we add
+          # generator here because we don't want split it in 'args=($astr)' above.
+          args+=( -G "${{ matrix.generator }}" )
+
+          # Print the resulting command line for debugging purposes
+          echo "cmake ${args[@]}"
+
+          # Run
+          cmake "${args[@]}"
+
+      - name: Fast Build
         run: cmake --build ${{ matrix.build-dir }} --config ${{ matrix.build-type }}
 
       - name: Standard Tests


### PR DESCRIPTION
This is a planned, intermediate change that prepares the following things:

- Preparing to use different generators (Xcode, NMake, Ninja)
- Preparing to use rebuild and test documentation (thanks to https://github.com/skvadrik/re2c/pull/326). This required renaming some steps
- Preparing to build libs
- Preparing to use Autotools
- Preparing to make a full migration of CMake builds from Travis CI

Notable improvements include the unification of the Configure job (now it is Fast Configure) for all platforms