### PR TITLE
Complete CI implementation using CMake and GitHub  Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,26 @@ jobs:
               ;;
           esac
 
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+          architecture: x64
+
+      - name: Get PIP Cache Key
+        id: pip-cache
+        run: |
+          python -c "from pip._internal.locations import USER_CACHE_DIR; \
+                     print('::set-output name=dir::' + USER_CACHE_DIR)"
+
+      - name: Install Python Dependencies
+        # Disabled until this https://github.com/skvadrik/re2c/issues/327
+        # will be implemented
+        if: startsWith(runner.os, 'Windows') == false
+        run: |
+          python -m pip install --upgrade pip
+          pip install docutils pygments
+
       - name: Prepare Configure Command
         id: configure-command
         run: |
@@ -179,7 +199,6 @@ jobs:
 
           echo "::set-output name=cmake::${args[@]}"
 
-      #
       - name: Fast Configure
         run: |
           # Read prepared command into an array
@@ -188,6 +207,10 @@ jobs:
 
           # Amend Build Options
           args+=( -DCMAKE_INSTALL_PREFIX="$(pwd)/install" )
+
+          # Disable some defaults for now to speed up the build as
+          # they are not necessary in a minimal installation
+          args+=( -DRE2C_BUILD_RE2GO=OFF )
 
           # Generator's specific stuff
           #
@@ -204,6 +227,54 @@ jobs:
       - name: Fast Build
         run: cmake --build ${{ matrix.build-dir }} --config ${{ matrix.build-type }}
 
+      - name: Install
+        run: |
+          cmake --build ${{ matrix.build-dir }} --config ${{ matrix.build-type }} --target install
+          echo -e "Install tree:\n$(find install | sed 's/^/-- /')"
+
+      - name: Minimal Install Test
+        working-directory: ./install/bin
+        run: ./re2c --version
+
+      - name: Full Configure
+        run: |
+          # Read prepared command into an array
+          astr="${{ steps.configure-command.outputs.cmake }}"
+          args=($astr)
+
+          # Amend Build Options
+          args+=( -DCMAKE_INSTALL_PREFIX="$(pwd)/install-2" -DRE2C_BUILD_RE2GO=ON -DRE2C_BUILD_LIBS=ON )
+          args+=( -DRE2C_REBUILD_LEXERS=ON -DRE2C_FOR_BUILD="$(pwd)/install/bin/re2c" )
+
+          # Windows does not have a native 'man' and 'sed' commands.
+          # Disabled until this https://github.com/skvadrik/re2c/issues/327
+          # will be implemented
+          case ${{ runner.os }} in
+            Windows*)
+              args+=( -DRE2C_REBUILD_DOCS=OFF )
+              ;;
+            *)
+              args+=( -DRE2C_REBUILD_DOCS=ON )
+              ;;
+          esac
+
+          # Generator's specific stuff
+          #
+          # Notice, some generator names contains a space, this is why we add
+          # generator here because we don't want split it in 'args=($astr)' above.
+          args+=( -G "${{ matrix.generator }}" )
+
+          # Print the resulting command line for debugging purposes
+          echo "cmake ${args[@]}"
+
+          # Run
+          cmake "${args[@]}"
+
+      - name: Full Build
+        run: |
+          find src -name '*.re' | xargs touch
+          cmake --build ${{ matrix.build-dir }} --config ${{ matrix.build-type }} --verbose
+
       - name: Standard Tests
         if: startsWith(runner.os, 'Windows') == false &&  matrix.skeleton == false
         run: cmake --build ${{ matrix.build-dir }} --target check
@@ -212,14 +283,3 @@ jobs:
         if: startsWith(runner.os, 'Windows') == false && matrix.skeleton == true
         working-directory: ${{ matrix.build-dir }}
         run: ./run_tests.sh --skeleton
-
-      - name: Install
-        run: |
-          cmake --build ${{ matrix.build-dir }} --config ${{ matrix.build-type }} --target install
-          echo -e "Install tree:\n$(find install | sed 's/^/-- /')"
-
-      - name: Minimal Install Test
-        working-directory: ./install/bin
-        run: |
-          ./re2c --version
-          ./re2go --version


### PR DESCRIPTION
This PR adds ability to build re2c on GitHub Actions with the following options:

- **`-DRE2C_REBUILD_LEXERS=ON`**: Windows, macOs, Linux
- **`-DRE2C_BUILD_LIBS=ON`**: Windows, macOs, Linux
- **`-DRE2C_REBUILD_DOCS=ON`**: macOs, Linux

With this PR I completely implement CI on GitHub Actions using CMake. Current workflow configuration fully cover the Travis' configuration (even more).