### PR TITLE
skeleton: delete '.input' and '.keys' files before overwriting them

### DIFF
--- a/src/skeleton/generate_data.cc
+++ b/src/skeleton/generate_data.cc
@@ -483,12 +483,16 @@ void emit_data(Skeleton &skel)
     }
 
     const std::string input_name = fname + "." + skel.name + ".input";
+    const std::string keys_name = std::string(fname) + "." + skel.name + ".keys";
+    // 'remove() / fopen("w")' works faster than 'fopen("w")' at least on ext4.
+    remove(input_name.c_str());
+    remove(keys_name.c_str());
+
     FILE *input = fopen(input_name.c_str(), "wb");
     if (!input) {
         error("cannot open file: %s", input_name.c_str());
         exit(1);
     }
-    const std::string keys_name = std::string(fname) + "." + skel.name + ".keys";
     FILE *keys = fopen (keys_name.c_str(), "wb");
     if (!keys) {
         error("cannot open file: %s", keys_name.c_str());


### PR DESCRIPTION
At least on ext4 `open(O_TRUNC); write(); close()` works a lot
slower than `unlink(); open(); write(); close()`.

My speculation is that ext4 has to do non-trivial free block
accounting at `close()` time that were freed by `O_TRUNC`.

Before the patch:

```
$ rm 1.c.line8.input 1.c.line8.keys; time ../re2c bug128.re -o 1.c -Si
real    0m3,011s
user    0m2,091s
sys     0m0,907s

$ time ../re2c bug128.re -o 1.c -Si
real    0m9,506s
user    0m1,708s
sys     0m0,946s
```

After the patch:

```
$ rm 1.c.line8.input 1.c.line8.keys;  time ../re2c bug128.re -o 1.c -Si
real    0m3,785s
user    0m2,615s
sys     0m1,152s

$ time ../re2c bug128.re -o 1.c -Si
real    0m3,570s
user    0m2,348s
sys     0m1,205s
```

It's a 3x speedup.