### PR TITLE
Fix compiling on Windows (MSVC)

### DIFF
--- a/src/compile.cc
+++ b/src/compile.cc
@@ -4,6 +4,7 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#include <cctype>
 
 #include "src/adfa/adfa.h"
 #include "src/codegen/code.h"
@@ -36,7 +37,7 @@ static std::string make_name(Output &output, const std::string &cond, const loc_
     if (loc.file > 0) {
         name += output.msg.filenames[loc.file];
         for (size_t i = 0; i < name.length(); ++i) {
-            if (!std::isalnum(name[i])) name[i] = '_';
+            if (!std::isalnum(static_cast<unsigned char>(name[i]))) name[i] = '_';
         }
         name += "_";
     }


### PR DESCRIPTION
Hi,

By trying to build re2c on Windows, using MSVS 2017 I faced the compile-time error: C2039: 'isalnum': is not a member of 'std'. This PR fixes this issue.

By the way I added a small fix of using this function: in order to avoid UB (which may occur in some situations, see links below) the argument should be passed by preliminary converting it to unsigned char. More info about this issue:
-  https://stackoverflow.com/a/39520176/1117306
-  https://en.cppreference.com/w/cpp/string/byte/isalnum. 