### PR TITLE
Enable support of C++ exceptions on MSVC builds.

### DIFF
--- a/cmake/Re2cCompilerFlags.cmake
+++ b/cmake/Re2cCompilerFlags.cmake
@@ -56,6 +56,7 @@ else()
     # /Wall enables all warnings that are off by default including
     # some of the ones GCC/Clang enables through -Wxxxx flags.
     try_cxxflag("/Wall")
+    try_cxxflag("/EHsc")    # Support C++ exceptions.
 endif()
 
 # Print compiler and linker flags


### PR DESCRIPTION
HI,

By looking at build log on Windows (MSVC) I noticed a number of warnings of the form:
`'noexcept' used with no exception handling mode specified; termination on exception is not guaranteed. Specify /EHsc (compiling source file ...src\codegen\gen_state.cc)`

If I recall correctly from my experience, if this flag isn't set then we may encounter situations when destructors of automatic objects aren't called during the exception propagation process. 

The following doc also recommends (if project doesn't use SEH) to set this flag:
https://docs.microsoft.com/ru-ru/cpp/build/reference/eh-exception-handling-model?view=msvc-160