### PR TITLE
configure.ac: avoid bash-specific '==' comparison

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ AM_CONDITIONAL([WITH_GOLANG], [test "x$enable_golang" != "xno"])
 # --enable-benchmarks
 AC_ARG_ENABLE([benchmarks], [AS_HELP_STRING([--enable-benchmarks],
     [build benchmarks])])
-AM_CONDITIONAL([WITH_BENCHMARKS], [test "x$enable_benchmarks" == "xyes"])
+AM_CONDITIONAL([WITH_BENCHMARKS], [test "x$enable_benchmarks" = "xyes"])
 AM_COND_IF([WITH_BENCHMARKS], [
     AC_LANG_PUSH([C++])
     AC_CHECK_HEADERS([benchmark/benchmark.h], [],
@@ -79,7 +79,7 @@ AC_ARG_ENABLE([benchmarks_regenerate],
     [AS_HELP_STRING([--enable-benchmarks-regenerate],
     [regenerate C code for benchmarks])])
 AM_CONDITIONAL([REGEN_BENCHMARKS],
-    [test "x$enable_benchmarks_regenerate" == "xyes"])
+    [test "x$enable_benchmarks_regenerate" = "xyes"])
 
 
 # checks for programs


### PR DESCRIPTION
In https://bugs.gentoo.org/779187 Matt noticed errors when running ./configure
on dash:
    ./configure: 5339: test: x: unexpected operator
    ./configure: 5386: test: x: unexpected operator

The change is to use POSIX '=' comparison instead of bash-specific ==.

Patch-by: Matt Whitlock
Bug: https://bugs.gentoo.org/779187