### PR TITLE
Run regular re2c tests on macOs too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,13 @@ jobs:
             skeleton: ${{ true }}
 
           # macOS
-          - name: macos-clang-debug-ootree-skeleton
+          - name: macos-clang-debug-ootree
             os: macos-latest
             generator: Unix Makefiles
             build-type: Debug
             build-dir: .build
             cxx-flags: -O2
-            skeleton: ${{ true }}
+            skeleton: ${{ false }}
 
           - name: macos-clang-debug-intree-skeleton
             os: macos-latest


### PR DESCRIPTION
I noticed that we don't run regular re2c tests for macOs. `macos-clang-debug-ootree-skeleton` and `macos-clang-debug-intree-skeleton` are very similar, so I changed `skeleton: ${{ true }}` to `skeleton: ${{ false }}` to run non-skeleton tests on macOs too.

With change we'll have the following tests matrix:

**Linux**

- skeleton tests: 3
- non-skeleton tests: 2

**macOS**

- skeleton tests: 2
- non-skeleton tests: 1  (I introduced this)

**Windows**

- skeleton tests: 0
- non-skeleton tests: 3