### PR TITLE
configure.ac: allow user to set non-standard PYTHON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ option(RE2C_REGEN_BENCHMARKS "Regenerate C code for benchmarks" OFF)
 
 # checks for programs
 find_package(BISON)
+find_package(Python3 COMPONENTS Interpreter)
 
 # checks for C++ compiler flags
 set(CMAKE_CXX_STANDARD 98)
@@ -96,11 +97,11 @@ set(re2c_docs
 
 set(top_srcdir "${CMAKE_CURRENT_SOURCE_DIR}")
 set(top_builddir "${CMAKE_CURRENT_BINARY_DIR}")
+set(PYTHON "${Python3_EXECUTABLE}")
 
 configure_file(doc/manpage.rst.in doc/manpage.rst @ONLY)
 configure_file(doc/help.rst.in doc/help.rst @ONLY)
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
 configure_file(run_tests.py.in run_tests.py @ONLY)
 set(RE2C_RUN_TESTS "${CMAKE_CURRENT_BINARY_DIR}/run_tests.py")
 

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,7 @@ AM_CONDITIONAL([REGEN_BENCHMARKS],
 
 # checks for programs
 AC_PATH_PROG(BISON, bison, no)
+AC_CHECK_PROGS(PYTHON, [python3 python])
 AC_PROG_CC # used in skeleton tests
 AC_PROG_CXX
 AC_PROG_INSTALL

--- a/run_tests.py.in
+++ b/run_tests.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env @PYTHON@
 
 import argparse
 import errno


### PR DESCRIPTION
Useful on systems with multiple python implementations.
While at it allow both 'python3' (preferred) and 'python' spellings.