### PR TITLE
Define _POSIX_SOURCE for fdopen in cygwin

### DIFF
--- a/src/util/temp_file.cc
+++ b/src/util/temp_file.cc
@@ -1,3 +1,7 @@
+#ifndef _POSIX_SOURCE
+#define _POSIX_SOURCE 1 // for fdopen
+#endif
+
 #include "config.h"
 #include <time.h>
 #include "src/util/temp_file.h"


### PR DESCRIPTION
This fixes the error:
error: ‘fdopen’ was not declared in this scope; did you mean ‘fopen’?