### PR TITLE
Setup Java for the benchmarks workflow using actions/setup-java

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: '3.8'
 
       - name: Setup Java
-        uses: actions/setup-python@v2
+        uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: '11'


### PR DESCRIPTION
Use `actions/setup-java` instead of `actions/setup-python` for the `Setup Java` step in the benchmarks workflow. Something seemed off about the action that was currently being used for setting up Java.