### PR TITLE
fix struct/class declaration mismatch (-Wmismatched-tags)

### DIFF
--- a/src/codegen/code.h
+++ b/src/codegen/code.h
@@ -32,7 +32,7 @@ struct Code;
 struct CodeGo;
 struct CodeGoIf;
 class Output;
-class OutputBlock;
+struct OutputBlock;
 struct State;
 struct DFA;
 typedef std::vector<smart_ptr<DFA> > dfas_t;

--- a/src/options/symtab.h
+++ b/src/options/symtab.h
@@ -9,7 +9,7 @@ namespace re2c {
 
 struct AST;
 struct loc_t;
-struct Msg;
+class Msg;
 
 typedef std::map<std::string, const AST*> symtab_t;
 

--- a/src/regexp/re.h
+++ b/src/regexp/re.h
@@ -14,7 +14,7 @@ namespace re2c {
 
 struct AST;
 struct ASTRule;
-struct Msg;
+class Msg;
 struct Rule;
 struct opt_t;
 


### PR DESCRIPTION
Detected by clang's-Weverything:

    ./src/regexp/re.h:17:1: warning: struct 'Msg' was previously declared as a class;
      this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
    struct Msg;
    ^