### PR TITLE
avoid using reserved identifiers (underscores)

### DIFF
--- a/src/parse/ast.h
+++ b/src/parse/ast.h
@@ -13,7 +13,7 @@
 namespace re2c {
 
 struct SemAct;
-template <class _Ty> class free_list;
+template <class Ty> class free_list;
 
 struct ASTChar {
     uint32_t chr;

--- a/src/util/free_list.h
+++ b/src/util/free_list.h
@@ -6,25 +6,25 @@
 
 namespace re2c {
 
-template<class _Ty>
-class free_list: protected std::set<_Ty>
+template<class Ty>
+class free_list: protected std::set<Ty>
 {
 public:
-    typedef typename std::set<_Ty>::iterator   iterator;
-    typedef typename std::set<_Ty>::size_type  size_type;
-    typedef typename std::set<_Ty>::key_type   key_type;
+    typedef typename std::set<Ty>::iterator   iterator;
+    typedef typename std::set<Ty>::size_type  size_type;
+    typedef typename std::set<Ty>::key_type   key_type;
     
     free_list(): in_clear(false)
     {
     }
     
-    using std::set<_Ty>::insert;
+    using std::set<Ty>::insert;
 
     size_type erase(const key_type& key)
     {
         if (!in_clear)
         {
-            return std::set<_Ty>::erase(key);
+            return std::set<Ty>::erase(key);
         }
         return 0;
     }
@@ -37,7 +37,7 @@ public:
         {
             delete *it;
         }
-        std::set<_Ty>::clear();
+        std::set<Ty>::clear();
         
         in_clear = false;
     }


### PR DESCRIPTION
clang with -Weverything detects these as:

    ./src/util/free_list.h:9:16:
      warning: identifier '_Ty' is reserved
      because it starts with '_' followed by a capital letter [-Wreserved-identifier]
    template<class _Ty>
                   ^