### PR TITLE
CMakePresets.json: inherit "full" configuration before "fast".

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,7 +53,7 @@
     {
       "name": "linux-gcc-ubsan-ootree-full",
       "displayName": "Linux x86_64: GCC / Ubsan / Out of tree (full)",
-      "inherits": ["linux-gcc-ubsan-ootree-fast", "default-full-configuration"]
+      "inherits": ["default-full-configuration", "linux-gcc-ubsan-ootree-fast"]
     },
     {
       "name": "linux-gcc-asan-ootree-fast",
@@ -71,7 +71,7 @@
     {
       "name": "linux-gcc-asan-ootree-full",
       "displayName": "Linux x86_64: GCC / Asan / Out of tree (full)",
-      "inherits": ["linux-gcc-asan-ootree-fast", "default-full-configuration"]
+      "inherits": ["default-full-configuration", "linux-gcc-asan-ootree-fast"]
     },
     {
       "name": "linux-gcc-debug-ootree-skeleton-fast",
@@ -89,7 +89,7 @@
     {
       "name": "linux-gcc-debug-ootree-skeleton-full",
       "displayName": "Linux x86_64: GCC / Debug / Skeleton / Out of tree (full)",
-      "inherits": ["linux-gcc-debug-ootree-skeleton-fast", "default-full-configuration"]
+      "inherits": ["default-full-configuration", "linux-gcc-debug-ootree-skeleton-fast"]
     },
     {
       "name": "linux-gcc-debug-intree-m32-skeleton-fast",
@@ -113,7 +113,7 @@
     {
       "name": "linux-gcc-debug-intree-m32-skeleton-full",
       "displayName": "Linux x86: GCC / Debug / Skeleton / In tree (full)",
-      "inherits": ["linux-gcc-debug-intree-m32-skeleton-fast", "default-full-configuration"]
+      "inherits": ["default-full-configuration", "linux-gcc-debug-intree-m32-skeleton-fast"]
     },
     {
       "name": "linux-gcc-release-ootree-skeleton-fast",
@@ -129,7 +129,7 @@
     {
       "name": "linux-gcc-release-ootree-skeleton-full",
       "displayName": "Linux x86_64: GCC / Release / Skeleton / Out of tree (full)",
-      "inherits": ["linux-gcc-release-ootree-skeleton-fast", "default-full-configuration"]
+      "inherits": ["default-full-configuration", "linux-gcc-release-ootree-skeleton-fast"]
     },
 
 
@@ -167,7 +167,7 @@
     {
       "name": "macos-clang-debug-ootree-skeleton-full",
       "displayName": "macOS x86_64: Clang / Debug / Skeleton / Out of tree (full)",
-      "inherits": ["macos-clang-debug-ootree-skeleton-fast", "default-full-configuration"]
+      "inherits": ["default-full-configuration", "macos-clang-debug-ootree-skeleton-fast"]
     },
     {
       "name": "macos-clang-debug-intree-skeleton-fast",
@@ -185,7 +185,7 @@
     {
       "name": "macos-clang-debug-intree-skeleton-full",
       "displayName": "macOS x86_64: Clang / Debug / Skeleton / In tree (full)",
-      "inherits": ["macos-clang-debug-intree-skeleton-fast", "default-full-configuration"]
+      "inherits": ["default-full-configuration", "macos-clang-debug-intree-skeleton-fast"]
     },
     {
       "name": "macos-clang-release-ootree-skeleton-fast",
@@ -201,7 +201,7 @@
     {
       "name": "macos-clang-release-ootree-skeleton-full",
       "displayName": "macOS x86_64: CLang / Release / Skeleton / Out of tree (full)",
-      "inherits": ["macos-clang-release-ootree-skeleton-fast", "default-full-configuration"]
+      "inherits": ["default-full-configuration", "macos-clang-release-ootree-skeleton-fast"]
     },
 
 
@@ -237,7 +237,7 @@
     {
       "name": "windows-msvc-debug-ootree-full",
       "displayName": "Windows x86_64: MSVC / Debug / Out of tree (full)",
-      "inherits": ["windows-msvc-debug-ootree-fast", "default-full-configuration"],
+      "inherits": ["default-full-configuration", "windows-msvc-debug-ootree-fast"],
       "cacheVariables": {
         "RE2C_REBUILD_DOCS": false
       }
@@ -256,7 +256,7 @@
     {
       "name": "windows-msvc-debug-intree-full",
       "displayName": "Windows x86_64: MSVC / Debug / In tree (full)",
-      "inherits": ["windows-msvc-debug-intree-fast", "default-full-configuration"],
+      "inherits": ["default-full-configuration", "windows-msvc-debug-intree-fast"],
       "cacheVariables": {
         "RE2C_REBUILD_DOCS": false
       }
@@ -275,7 +275,7 @@
     {
       "name": "windows-msvc-release-ootree-full",
       "displayName": "Windows x86_64: MSVC / Release / Out of tree (full)",
-      "inherits": ["windows-msvc-release-ootree-fast", "default-full-configuration"],
+      "inherits": ["default-full-configuration", "windows-msvc-release-ootree-fast"],
       "cacheVariables": {
         "RE2C_REBUILD_DOCS": false
       }

--- a/cmake/Re2cGenDocs.cmake
+++ b/cmake/Re2cGenDocs.cmake
@@ -1,8 +1,10 @@
 function(re2c_gen_manpage source target bootstrap lang)
     if(RE2C_REBUILD_DOCS)
+        get_filename_component(targetdir "${target}" DIRECTORY)
         set(source_l "${source}.${lang}")
         add_custom_command(
             OUTPUT "${target}"
+            COMMAND "${CMAKE_COMMAND}" -E make_directory ${targetdir}
             COMMAND "${re2c_splitman}" "${source}" "${source_l}" "${lang}"
             COMMAND "${RST2MAN}" --tab-width=4 "${source_l}" "${target}"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${target}" "${bootstrap}"
@@ -23,8 +25,10 @@ endfunction()
 
 function(re2c_gen_help source target bootstrap)
     if(RE2C_REBUILD_DOCS)
+        get_filename_component(targetdir "${target}" DIRECTORY)
         add_custom_command(
             OUTPUT "${target}"
+            COMMAND "${CMAKE_COMMAND}" -E make_directory ${targetdir}
             COMMAND "${RST2MAN}" "${source}" "${target}.1"
             COMMAND "${re2c_genhelp}" "${target}.1" "${target}"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${target}" "${bootstrap}"


### PR DESCRIPTION
Otherwise variable definitions from "fast" configuration take precedence
over the "full" configuration, resulting in disabling some important
configrations, such as Go language support.

For example, if "fast" is inherited before "full" we have the following
incorrect configrations that sets RE2C_BUILD_RE2GO:BOOL="FALSE":

  $ cmake -S .. --preset=linux-gcc-release-ootree-skeleton-full
  Preset CMake variables:

    CMAKE_BUILD_TYPE="Release"
    CMAKE_CXX_COMPILER="g++"
    CMAKE_C_COMPILER="gcc"
    CMAKE_INSTALL_PREFIX:PATH="[CUT]/re2c/install"
    RE2C_BUILD_LIBS:BOOL="TRUE"
    RE2C_BUILD_RE2GO:BOOL="FALSE"
    RE2C_FOR_BUILD="[CUT]/re2c/install/bin/re2c"
    RE2C_REBUILD_DOCS:BOOL="TRUE"
    RE2C_REBUILD_LEXERS:BOOL="TRUE"

But if "full" is inherited after "fast" we have the following (correct):

  $ cmake -S .. --preset=linux-gcc-release-ootree-skeleton-full
  Preset CMake variables:

    CMAKE_BUILD_TYPE="Release"
    CMAKE_CXX_COMPILER="g++"
    CMAKE_C_COMPILER="gcc"
    CMAKE_INSTALL_PREFIX:PATH="[CUT]/re2c/install-2"
    RE2C_BUILD_LIBS:BOOL="TRUE"
    RE2C_BUILD_RE2GO:BOOL="TRUE"
    RE2C_FOR_BUILD="[CUT]/re2c/install/bin/re2c"
    RE2C_REBUILD_DOCS:BOOL="TRUE"
    RE2C_REBUILD_LEXERS:BOOL="TRUE"