### PR TITLE
.github/workflows/ci.yml: set up trivial apt cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           case ${{ runner.os }} in
             Linux*)
+              sudo apt update
               sudo apt install gcc-multilib g++-multilib  # for -m32
               ;;
             macOS*)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,16 @@ jobs:
             ${{ runner.os }}-chocolatey-${{ matrix.os }}-
             ${{ runner.os }}-chocolatey-
 
+      - name: Setup apt cache (Linux)
+        if: startsWith(runner.os, 'Linux')
+        uses: actions/cache@v2
+        with:
+          path: /var/cache/apt
+          key: ${{ runner.os }}-apt-cache-${{ matrix.os }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-apt-cache-${{ matrix.os }}-
+            ${{ runner.os }}-apt-cache-
+
       - name: Setup Common Prerequisites
         run: |
           case ${{ runner.os }} in


### PR DESCRIPTION
CI runs occasionally fail to fetch apt packages due to unavailable
remote. Let's try to cache heavyweight .deb packages and see if it
helps.

.deb files should not normally change frequently.