### PR TITLE
.github/workflows: rename ci.yml to ci-cmake.yml

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI CMake
 
 on:
   push:


### PR DESCRIPTION
A prerequisite for basic autotools-based build.