### PR TITLE
Enable bison warnings

### DIFF
--- a/.github/workflows/ci-autotools.yml
+++ b/.github/workflows/ci-autotools.yml
@@ -61,6 +61,10 @@ jobs:
               echo "$(xcodebuild -version -sdk macosx Path)" >> $GITHUB_PATH
 
               brew install autoconf automake libtool bison coreutils
+              # bison is not activated by default to avoid clobbering
+              # already present outdated system bison. Let's prepend
+              # brew's path.
+              echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
               ;;
           esac
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -362,7 +362,7 @@ if REBUILD_PARSERS
 # generate lexer and update bootstrap files
 .ypp.cc:
 	$(AM_V_at)$(MKDIR_P) $(@D)
-	$(AM_V_GEN)$(BISON) --output=$@ --defines=$(@:cc=h) $<
+	$(AM_V_GEN)$(BISON) --warnings --output=$@ --defines=$(@:cc=h) $<
 	$(AM_V_GEN)cp $@ $(@:cc=h) $(top_srcdir)/bootstrap/$(@D);
 else
 # copy bootstrap files

--- a/cmake/Re2cBootstrapParser.cmake
+++ b/cmake/Re2cBootstrapParser.cmake
@@ -10,7 +10,7 @@ function(re2c_bootstrap_parser ypp_file cc_file h_file)
         add_custom_command(
             OUTPUT ${cc_file} ${h_file}
             COMMAND "${CMAKE_COMMAND}" -E make_directory "${parent_dir}"
-            COMMAND "${BISON_EXECUTABLE}" --defines="${h_file}" -o "${cc_file}" "${relative_parser}"
+            COMMAND "${BISON_EXECUTABLE}" --warnings --defines="${h_file}" -o "${cc_file}" "${relative_parser}"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${cc_file}" "${bootstrap_parser}"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${h_file}" "${bootstrap_header}"
             DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${ypp_file}"

--- a/src/parse/parser.ypp
+++ b/src/parse/parser.ypp
@@ -57,7 +57,7 @@ extern "C" {
 %%
 
 spec
-: /* empty */
+: %empty
 | spec TOKEN_BLOCK {
     if (use_block(context, ast.temp_blockname) != Ret::OK) YYABORT;
     ast.temp_blockname.clear();


### PR DESCRIPTION
The change allows catching fresh bison diagnostics. Current example:

      GEN      src/parse/parser.cc
    src/parse/parser.ypp:60.2: warning: empty rule without %empty [-Wempty-rule]
       60 | : /* empty */
          |  ^
          |  %empty

%empty was introduced in bison-2.7.90 around 2013.