### PR TITLE
cmake/Re2cBootstrapParser.cmake: change flag order to match Makefile.am

### DIFF
--- a/cmake/Re2cBootstrapParser.cmake
+++ b/cmake/Re2cBootstrapParser.cmake
@@ -10,7 +10,7 @@ function(re2c_bootstrap_parser ypp_file cc_file h_file)
         add_custom_command(
             OUTPUT ${cc_file} ${h_file}
             COMMAND "${CMAKE_COMMAND}" -E make_directory "${parent_dir}"
-            COMMAND "${BISON_EXECUTABLE}" --warnings --defines="${h_file}" -o "${cc_file}" "${relative_parser}"
+            COMMAND "${BISON_EXECUTABLE}" --warnings --output="${cc_file}" --defines="${h_file}" "${relative_parser}"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${cc_file}" "${bootstrap_parser}"
             COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${h_file}" "${bootstrap_header}"
             DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${ypp_file}"


### PR DESCRIPTION
Autotools-based and cmake-based build systems had slightly different flag order:

    Makefile.am:    $(AM_V_GEN)$(BISON) --warnings --output=$@ --defines=$(@:cc=h) $<

Let's make them identical.