### PR TITLE
bison parsers: switch to pure bison API

### DIFF
--- a/bootstrap/lib/lex.cc
+++ b/bootstrap/lib/lex.cc
@@ -11,7 +11,7 @@
 #include "parse.h"
 #include "lib/lex.h"
 
-extern YYSTYPE yylval;
+
 
 namespace re2c {
 
@@ -20,7 +20,7 @@ static int32_t lex_cls_chr(const uint8_t*&, uint32_t&);
 #line 27 "../lib/lex.re"
 
 
-int lex(const uint8_t*& cur, Ast& ast) {
+int lex(YYSTYPE* yylval, const uint8_t*& cur, Ast& ast) {
     
 #line 26 "lib/lex.cc"
 const uint8_t* yyt1;const uint8_t* yyt2;
@@ -106,7 +106,7 @@ yy3:
 #line 73 "../lib/lex.re"
 	{
         ast.temp_chars.push_back({cur[-1], NOWHERE});
-        yylval.regexp = ast.str(NOWHERE, false);
+        yylval->regexp = ast.str(NOWHERE, false);
         return TOKEN_REGEXP;
     }
 #line 113 "lib/lex.cc"
@@ -127,7 +127,7 @@ yy6:
 	++cur;
 #line 68 "../lib/lex.re"
 	{
-        yylval.regexp = ast.dot(NOWHERE);
+        yylval->regexp = ast.dot(NOWHERE);
         return TOKEN_REGEXP;
     }
 #line 134 "lib/lex.cc"
@@ -174,8 +174,8 @@ yy13:
 	x = yyt1;
 #line 50 "../lib/lex.re"
 	{
-        if (!s_to_u32_unsafe(x, cur - 1, yylval.bounds.min)) goto err_cnt;
-        yylval.bounds.max = yylval.bounds.min;
+        if (!s_to_u32_unsafe(x, cur - 1, yylval->bounds.min)) goto err_cnt;
+        yylval->bounds.max = yylval->bounds.min;
         return TOKEN_COUNT;
     }
 #line 182 "lib/lex.cc"
@@ -190,8 +190,8 @@ yy15:
 	x = yyt1;
 #line 62 "../lib/lex.re"
 	{
-        if (!s_to_u32_unsafe(x, cur - 2, yylval.bounds.min)) goto err_cnt;
-        yylval.bounds.max = Ast::MANY;
+        if (!s_to_u32_unsafe(x, cur - 2, yylval->bounds.min)) goto err_cnt;
+        yylval->bounds.max = Ast::MANY;
         return TOKEN_COUNT;
     }
 #line 198 "lib/lex.cc"
@@ -201,8 +201,8 @@ yy16:
 	y = yyt2;
 #line 56 "../lib/lex.re"
 	{
-        if (!s_to_u32_unsafe(x, y - 1, yylval.bounds.min)
-            || !s_to_u32_unsafe(y, cur - 1, yylval.bounds.max)) goto err_cnt;
+        if (!s_to_u32_unsafe(x, y - 1, yylval->bounds.min)
+            || !s_to_u32_unsafe(y, cur - 1, yylval->bounds.max)) goto err_cnt;
         return TOKEN_COUNT;
     }
 #line 209 "lib/lex.cc"
@@ -252,7 +252,7 @@ yy22:
 	++cur;
 #line 91 "../lib/lex.re"
 	{
-        yylval.regexp = ast.cls(NOWHERE, neg);
+        yylval->regexp = ast.cls(NOWHERE, neg);
         return TOKEN_REGEXP;
     }
 #line 259 "lib/lex.cc"

--- a/bootstrap/lib/parse.cc
+++ b/bootstrap/lib/parse.cc
@@ -55,7 +55,7 @@
 #define YYSKELETON_NAME "yacc.c"
 
 /* Pure parsers.  */
-#define YYPURE 0
+#define YYPURE 2
 
 /* Push parsers.  */
 #define YYPUSH 0
@@ -67,7 +67,7 @@
 
 
 /* First part of user prologue.  */
-#line 1 "../lib/parse.ypp"
+#line 9 "../lib/parse.ypp"
 
 
 #include <stdio.h>
@@ -83,13 +83,7 @@
 
 using namespace re2c;
 
-extern "C" {
-    int yylex(const uint8_t*& pattern, Ast& ast);
-    void yyerror(const uint8_t* pattern, Ast&, const char* msg) RE2C_ATTR((noreturn));
-}
-
-
-#line 93 "lib/parse.cc"
+#line 87 "lib/parse.cc"
 
 # ifndef YY_CAST
 #  ifdef __cplusplus
@@ -139,6 +133,16 @@ enum yysymbol_kind_t
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
 
+/* Second part of user prologue.  */
+#line 38 "../lib/parse.ypp"
+
+extern "C" {
+    int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast);
+    void yyerror(const uint8_t* pattern, Ast&, const char* msg) RE2C_ATTR((noreturn));
+}
+
+
+#line 146 "lib/parse.cc"
 
 
 #ifdef short
@@ -521,8 +525,8 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int8 yyrline[] =
 {
-       0,    44,    44,    47,    48,    52,    53,    57,    58,    59,
-      60,    61,    65,    66,    67
+       0,    55,    55,    58,    59,    63,    64,    68,    69,    70,
+      71,    72,    76,    77,    78
 };
 #endif
 
@@ -833,13 +837,6 @@ yydestruct (const char *yymsg,
 }
 
 
-/* Lookahead token kind.  */
-int yychar;
-
-/* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval;
-/* Number of syntax errors so far.  */
-int yynerrs;
 
 
 
@@ -851,6 +848,19 @@ int yynerrs;
 int
 yyparse (const uint8_t*& pattern, re2c::Ast& ast)
 {
+/* Lookahead token kind.  */
+int yychar;
+
+
+/* The semantic value of the lookahead symbol.  */
+/* Default value used for initialization, for pacifying older GCCs
+   or non-GCC compilers.  */
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
+
+    /* Number of syntax errors so far.  */
+    int yynerrs = 0;
+
     yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
     int yyerrstatus = 0;
@@ -1003,7 +1013,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token\n"));
-      yychar = yylex (pattern, ast);
+      yychar = yylex (&yylval, pattern, ast);
     }
 
   if (yychar <= YYEOF)
@@ -1091,61 +1101,61 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* regexp: expr  */
-#line 44 "../lib/parse.ypp"
+#line 55 "../lib/parse.ypp"
              { regexp = (yyval.regexp); }
-#line 1097 "lib/parse.cc"
+#line 1107 "lib/parse.cc"
     break;
 
   case 4: /* expr: expr '|' term  */
-#line 48 "../lib/parse.ypp"
+#line 59 "../lib/parse.ypp"
                 { (yyval.regexp) = ast.alt((yyvsp[-2].regexp), (yyvsp[0].regexp)); }
-#line 1103 "lib/parse.cc"
+#line 1113 "lib/parse.cc"
     break;
 
   case 6: /* term: factor term  */
-#line 53 "../lib/parse.ypp"
+#line 64 "../lib/parse.ypp"
               { (yyval.regexp) = ast.cat((yyvsp[-1].regexp), (yyvsp[0].regexp)); }
-#line 1109 "lib/parse.cc"
+#line 1119 "lib/parse.cc"
     break;
 
   case 8: /* factor: primary '*'  */
-#line 58 "../lib/parse.ypp"
+#line 69 "../lib/parse.ypp"
                       { (yyval.regexp) = ast.iter((yyvsp[-1].regexp), 0, Ast::MANY); }
-#line 1115 "lib/parse.cc"
+#line 1125 "lib/parse.cc"
     break;
 
   case 9: /* factor: primary '+'  */
-#line 59 "../lib/parse.ypp"
+#line 70 "../lib/parse.ypp"
                       { (yyval.regexp) = ast.iter((yyvsp[-1].regexp), 1, Ast::MANY); }
-#line 1121 "lib/parse.cc"
+#line 1131 "lib/parse.cc"
     break;
 
   case 10: /* factor: primary '?'  */
-#line 60 "../lib/parse.ypp"
+#line 71 "../lib/parse.ypp"
                       { (yyval.regexp) = ast.iter((yyvsp[-1].regexp), 0, 1); }
-#line 1127 "lib/parse.cc"
+#line 1137 "lib/parse.cc"
     break;
 
   case 11: /* factor: primary TOKEN_COUNT  */
-#line 61 "../lib/parse.ypp"
+#line 72 "../lib/parse.ypp"
                       { (yyval.regexp) = ast.iter((yyvsp[-1].regexp), (yyvsp[0].bounds).min, (yyvsp[0].bounds).max); }
-#line 1133 "lib/parse.cc"
+#line 1143 "lib/parse.cc"
     break;
 
   case 13: /* primary: '(' ')'  */
-#line 66 "../lib/parse.ypp"
+#line 77 "../lib/parse.ypp"
                { (yyval.regexp) = ast.cap(ast.nil(NOWHERE)); }
-#line 1139 "lib/parse.cc"
+#line 1149 "lib/parse.cc"
     break;
 
   case 14: /* primary: '(' expr ')'  */
-#line 67 "../lib/parse.ypp"
+#line 78 "../lib/parse.ypp"
                { (yyval.regexp) = ast.cap((yyvsp[-1].regexp)); }
-#line 1145 "lib/parse.cc"
+#line 1155 "lib/parse.cc"
     break;
 
 
-#line 1149 "lib/parse.cc"
+#line 1159 "lib/parse.cc"
 
       default: break;
     }
@@ -1338,7 +1348,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 70 "../lib/parse.ypp"
+#line 81 "../lib/parse.ypp"
 
 
 #pragma GCC diagnostic pop
@@ -1349,8 +1359,8 @@ extern "C" {
         exit(1);
     }
 
-    int yylex(const uint8_t*& pattern, Ast& ast) {
-        return lex(pattern, ast);
+    int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast) {
+        return lex(yylval, pattern, ast);
     }
 }
 

--- a/bootstrap/lib/parse.h
+++ b/bootstrap/lib/parse.h
@@ -44,6 +44,16 @@
 #if YYDEBUG
 extern int yydebug;
 #endif
+/* "%code requires" blocks.  */
+#line 1 "../lib/parse.ypp"
+
+/* pull in types to populate YYSTYPE: */
+#include "src/parse/ast.h"
+namespace re2c {
+    struct AstNode;
+};
+
+#line 57 "lib/parse.h"
 
 /* Token kinds.  */
 #ifndef YYTOKENTYPE
@@ -65,12 +75,12 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 30 "../lib/parse.ypp"
+#line 33 "../lib/parse.ypp"
 
     const re2c::AstNode* regexp;
     re2c::AstBounds bounds;
 
-#line 74 "lib/parse.h"
+#line 84 "lib/parse.h"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -79,7 +89,6 @@ typedef union YYSTYPE YYSTYPE;
 #endif
 
 
-extern YYSTYPE yylval;
 
 
 int yyparse (const uint8_t*& pattern, re2c::Ast& ast);

--- a/bootstrap/src/parse/parser.cc
+++ b/bootstrap/src/parse/parser.cc
@@ -55,7 +55,7 @@
 #define YYSKELETON_NAME "yacc.c"
 
 /* Pure parsers.  */
-#define YYPURE 0
+#define YYPURE 2
 
 /* Push parsers.  */
 #define YYPUSH 0
@@ -67,7 +67,7 @@
 
 
 /* First part of user prologue.  */
-#line 1 "../src/parse/parser.ypp"
+#line 11 "../src/parse/parser.ypp"
 
 
 #pragma GCC diagnostic push
@@ -80,7 +80,7 @@
 using namespace re2c;
 
 extern "C" {
-    int yylex(context_t& context, Ast& ast);
+    int yylex(YYSTYPE* yylval, context_t& context, Ast& ast);
     void yyerror(context_t& context, Ast& ast, const char*);
 }
 
@@ -544,11 +544,11 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    60,    60,    61,    65,    69,    70,    71,    75,    78,
-      85,    86,    89,    89,    92,    95,    98,   101,   107,   113,
-     119,   125,   132,   133,   138,   143,   144,   149,   150,   154,
-     155,   159,   161,   165,   166,   179,   185,   186,   190,   191,
-     192,   196,   197,   206
+       0,    71,    71,    72,    76,    80,    81,    82,    86,    89,
+      96,    97,   100,   100,   103,   106,   109,   112,   118,   124,
+     130,   136,   143,   144,   149,   154,   155,   160,   161,   165,
+     166,   170,   172,   176,   177,   190,   196,   197,   201,   202,
+     203,   207,   208,   217
 };
 #endif
 
@@ -895,13 +895,6 @@ yydestruct (const char *yymsg,
 }
 
 
-/* Lookahead token kind.  */
-int yychar;
-
-/* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval;
-/* Number of syntax errors so far.  */
-int yynerrs;
 
 
 
@@ -913,6 +906,19 @@ int yynerrs;
 int
 yyparse (re2c::context_t& context, re2c::Ast& ast)
 {
+/* Lookahead token kind.  */
+int yychar;
+
+
+/* The semantic value of the lookahead symbol.  */
+/* Default value used for initialization, for pacifying older GCCs
+   or non-GCC compilers.  */
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
+
+    /* Number of syntax errors so far.  */
+    int yynerrs = 0;
+
     yy_state_fast_t yystate = 0;
     /* Number of tokens to shift before error messages enabled.  */
     int yyerrstatus = 0;
@@ -1065,7 +1071,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token\n"));
-      yychar = yylex (context, ast);
+      yychar = yylex (&yylval, context, ast);
     }
 
   if (yychar <= YYEOF)
@@ -1153,177 +1159,177 @@ yyreduce:
   switch (yyn)
     {
   case 3: /* spec: spec TOKEN_BLOCK  */
-#line 61 "../src/parse/parser.ypp"
+#line 72 "../src/parse/parser.ypp"
                    {
     if (use_block(context, ast.temp_blockname) != Ret::OK) YYABORT;
     ast.temp_blockname.clear();
 }
-#line 1162 "src/parse/parser.cc"
+#line 1168 "src/parse/parser.cc"
     break;
 
   case 4: /* spec: spec TOKEN_CONF  */
-#line 65 "../src/parse/parser.ypp"
+#line 76 "../src/parse/parser.ypp"
                   {
     // Handled here, as the main lexer should not get access to opts under construction.
     if (context.input.lex_conf(context.opts) != Ret::OK) YYABORT;
 }
-#line 1171 "src/parse/parser.cc"
+#line 1177 "src/parse/parser.cc"
     break;
 
   case 8: /* def: name expr enddef  */
-#line 75 "../src/parse/parser.ypp"
+#line 86 "../src/parse/parser.ypp"
                    {
     if (add_named_def(context.opts.symtab, (yyvsp[-2].cstr), (yyvsp[-1].regexp), context.input) != Ret::OK) YYABORT;
 }
-#line 1179 "src/parse/parser.cc"
+#line 1185 "src/parse/parser.cc"
     break;
 
   case 9: /* def: name expr '/'  */
-#line 78 "../src/parse/parser.ypp"
+#line 89 "../src/parse/parser.ypp"
                 {
     context.input.msg.error(context.input.tok_loc(),
                             "trailing contexts are not allowed in named definitions");
     YYABORT;
 }
-#line 1189 "src/parse/parser.cc"
-    break;
-
-  case 10: /* name: TOKEN_ID '='  */
-#line 85 "../src/parse/parser.ypp"
-               { (yyval.cstr) = (yyvsp[-1].cstr); }
 #line 1195 "src/parse/parser.cc"
     break;
 
+  case 10: /* name: TOKEN_ID '='  */
+#line 96 "../src/parse/parser.ypp"
+               { (yyval.cstr) = (yyvsp[-1].cstr); }
+#line 1201 "src/parse/parser.cc"
+    break;
+
   case 14: /* rule: trailexpr TOKEN_CODE  */
-#line 92 "../src/parse/parser.ypp"
+#line 103 "../src/parse/parser.ypp"
                        {
     find_or_add_spec(context.specs, "").rules.push_back(AstRule((yyvsp[-1].regexp), (yyvsp[0].semact)));
 }
-#line 1203 "src/parse/parser.cc"
+#line 1209 "src/parse/parser.cc"
     break;
 
   case 15: /* rule: '*' TOKEN_CODE  */
-#line 95 "../src/parse/parser.ypp"
+#line 106 "../src/parse/parser.ypp"
                  {
     find_or_add_spec(context.specs, "").defs.push_back((yyvsp[0].semact));
 }
-#line 1211 "src/parse/parser.cc"
+#line 1217 "src/parse/parser.cc"
     break;
 
   case 16: /* rule: '$' TOKEN_CODE  */
-#line 98 "../src/parse/parser.ypp"
+#line 109 "../src/parse/parser.ypp"
                  {
     find_or_add_spec(context.specs, "").eofs.push_back((yyvsp[0].semact));
 }
-#line 1219 "src/parse/parser.cc"
+#line 1225 "src/parse/parser.cc"
     break;
 
   case 17: /* rule: TOKEN_CLIST trailexpr ccode  */
-#line 101 "../src/parse/parser.ypp"
+#line 112 "../src/parse/parser.ypp"
                               {
     for (const std::string& cond : ast.temp_condlist) {
         find_or_add_spec(context.specs, cond).rules.push_back(AstRule((yyvsp[-1].regexp), (yyvsp[0].semact)));
     }
     ast.temp_condlist.clear();
 }
-#line 1230 "src/parse/parser.cc"
+#line 1236 "src/parse/parser.cc"
     break;
 
   case 18: /* rule: TOKEN_CLIST '*' ccode  */
-#line 107 "../src/parse/parser.ypp"
+#line 118 "../src/parse/parser.ypp"
                         {
     for (const std::string& cond : ast.temp_condlist) {
         find_or_add_spec(context.specs, cond).defs.push_back((yyvsp[0].semact));
     }
     ast.temp_condlist.clear();
 }
-#line 1241 "src/parse/parser.cc"
+#line 1247 "src/parse/parser.cc"
     break;
 
   case 19: /* rule: TOKEN_CLIST '$' ccode  */
-#line 113 "../src/parse/parser.ypp"
+#line 124 "../src/parse/parser.ypp"
                         {
     for (const std::string& cond : ast.temp_condlist) {
         find_or_add_spec(context.specs, cond).eofs.push_back((yyvsp[0].semact));
     }
     ast.temp_condlist.clear();
 }
-#line 1252 "src/parse/parser.cc"
+#line 1258 "src/parse/parser.cc"
     break;
 
   case 20: /* rule: TOKEN_CSETUP TOKEN_CODE  */
-#line 119 "../src/parse/parser.ypp"
+#line 130 "../src/parse/parser.ypp"
                           {
     for (const std::string& cond : ast.temp_condlist) {
         find_or_add_spec(context.specs, cond).setup.push_back((yyvsp[0].semact));
     }
     ast.temp_condlist.clear();
 }
-#line 1263 "src/parse/parser.cc"
+#line 1269 "src/parse/parser.cc"
     break;
 
   case 21: /* rule: TOKEN_CZERO ccode  */
-#line 125 "../src/parse/parser.ypp"
+#line 136 "../src/parse/parser.ypp"
                     {
     const AstNode* r = ast.nil(context.input.tok_loc());
     find_or_add_spec(context.specs, "0").rules.push_back(AstRule(r, (yyvsp[0].semact)));
     ast.temp_condlist.clear();
 }
-#line 1273 "src/parse/parser.cc"
+#line 1279 "src/parse/parser.cc"
     break;
 
   case 23: /* ccode: TOKEN_CNEXT TOKEN_CODE  */
-#line 133 "../src/parse/parser.ypp"
+#line 144 "../src/parse/parser.ypp"
                          {
     (yyval.semact) = (yyvsp[0].semact);
     // parser needs to to update condition, but for the rest of the code actions are immutable
     const_cast<SemAct*>((yyval.semact))->cond = (yyvsp[-1].cstr); 
 }
-#line 1283 "src/parse/parser.cc"
+#line 1289 "src/parse/parser.cc"
     break;
 
   case 24: /* ccode: TOKEN_CJUMP  */
-#line 138 "../src/parse/parser.ypp"
+#line 149 "../src/parse/parser.ypp"
               {
     (yyval.semact) = ast.sem_act(context.input.tok_loc(), nullptr, (yyvsp[0].cstr), true);
 }
-#line 1291 "src/parse/parser.cc"
-    break;
-
-  case 25: /* trailexpr: expr  */
-#line 143 "../src/parse/parser.ypp"
-       { (yyval.regexp) = ast.cap((yyvsp[0].regexp)); }
 #line 1297 "src/parse/parser.cc"
     break;
 
+  case 25: /* trailexpr: expr  */
+#line 154 "../src/parse/parser.ypp"
+       { (yyval.regexp) = ast.cap((yyvsp[0].regexp)); }
+#line 1303 "src/parse/parser.cc"
+    break;
+
   case 26: /* trailexpr: expr '/' expr  */
-#line 144 "../src/parse/parser.ypp"
+#line 155 "../src/parse/parser.ypp"
                 {
     (yyval.regexp) = ast.cat(ast.cap((yyvsp[-2].regexp)), ast.cat(ast.tag(context.input.tok_loc(), nullptr, false), (yyvsp[0].regexp)));
 }
-#line 1305 "src/parse/parser.cc"
-    break;
-
-  case 28: /* expr: expr '|' diff  */
-#line 150 "../src/parse/parser.ypp"
-                { (yyval.regexp) = ast.alt((yyvsp[-2].regexp), (yyvsp[0].regexp)); }
 #line 1311 "src/parse/parser.cc"
     break;
 
-  case 30: /* diff: diff '\\' term  */
-#line 155 "../src/parse/parser.ypp"
-                 { (yyval.regexp) = ast.diff((yyvsp[-2].regexp), (yyvsp[0].regexp)); }
+  case 28: /* expr: expr '|' diff  */
+#line 161 "../src/parse/parser.ypp"
+                { (yyval.regexp) = ast.alt((yyvsp[-2].regexp), (yyvsp[0].regexp)); }
 #line 1317 "src/parse/parser.cc"
     break;
 
-  case 32: /* term: factor term  */
-#line 161 "../src/parse/parser.ypp"
-              { (yyval.regexp) = ast.cat((yyvsp[-1].regexp), (yyvsp[0].regexp)); }
+  case 30: /* diff: diff '\\' term  */
+#line 166 "../src/parse/parser.ypp"
+                 { (yyval.regexp) = ast.diff((yyvsp[-2].regexp), (yyvsp[0].regexp)); }
 #line 1323 "src/parse/parser.cc"
     break;
 
+  case 32: /* term: factor term  */
+#line 172 "../src/parse/parser.ypp"
+              { (yyval.regexp) = ast.cat((yyvsp[-1].regexp), (yyvsp[0].regexp)); }
+#line 1329 "src/parse/parser.cc"
+    break;
+
   case 34: /* factor: primary closes  */
-#line 166 "../src/parse/parser.ypp"
+#line 177 "../src/parse/parser.ypp"
                  {
     switch((yyvsp[0].op)) {
     case '*':
@@ -1337,43 +1343,43 @@ yyreduce:
         break;
     }
 }
-#line 1341 "src/parse/parser.cc"
+#line 1347 "src/parse/parser.cc"
     break;
 
   case 35: /* factor: primary TOKEN_CLOSESIZE  */
-#line 179 "../src/parse/parser.ypp"
+#line 190 "../src/parse/parser.ypp"
                           {
     (yyval.regexp) = ast.iter((yyvsp[-1].regexp), (yyvsp[0].bounds).min, (yyvsp[0].bounds).max);
 }
-#line 1349 "src/parse/parser.cc"
-    break;
-
-  case 37: /* closes: closes close  */
-#line 186 "../src/parse/parser.ypp"
-               { (yyval.op) = ((yyvsp[-1].op) == (yyvsp[0].op)) ? (yyvsp[-1].op) : '*'; }
 #line 1355 "src/parse/parser.cc"
     break;
 
-  case 38: /* close: '*'  */
-#line 190 "../src/parse/parser.ypp"
-      { (yyval.op) = '*'; }
+  case 37: /* closes: closes close  */
+#line 197 "../src/parse/parser.ypp"
+               { (yyval.op) = ((yyvsp[-1].op) == (yyvsp[0].op)) ? (yyvsp[-1].op) : '*'; }
 #line 1361 "src/parse/parser.cc"
     break;
 
-  case 39: /* close: '+'  */
-#line 191 "../src/parse/parser.ypp"
-      { (yyval.op) = '+'; }
+  case 38: /* close: '*'  */
+#line 201 "../src/parse/parser.ypp"
+      { (yyval.op) = '*'; }
 #line 1367 "src/parse/parser.cc"
     break;
 
-  case 40: /* close: '?'  */
-#line 192 "../src/parse/parser.ypp"
-      { (yyval.op) = '?'; }
+  case 39: /* close: '+'  */
+#line 202 "../src/parse/parser.ypp"
+      { (yyval.op) = '+'; }
 #line 1373 "src/parse/parser.cc"
     break;
 
+  case 40: /* close: '?'  */
+#line 203 "../src/parse/parser.ypp"
+      { (yyval.op) = '?'; }
+#line 1379 "src/parse/parser.cc"
+    break;
+
   case 42: /* primary: TOKEN_ID  */
-#line 197 "../src/parse/parser.ypp"
+#line 208 "../src/parse/parser.ypp"
            {
     (yyval.regexp) = find_def(context.opts.symtab, (yyvsp[0].cstr));
     if ((yyval.regexp) == nullptr) {
@@ -1383,17 +1389,17 @@ yyreduce:
         (yyval.regexp) = ast.ref((yyval.regexp), (yyvsp[0].cstr));
     }
 }
-#line 1387 "src/parse/parser.cc"
-    break;
-
-  case 43: /* primary: '(' expr ')'  */
-#line 206 "../src/parse/parser.ypp"
-               { (yyval.regexp) = ast.cap((yyvsp[-1].regexp)); }
 #line 1393 "src/parse/parser.cc"
     break;
 
+  case 43: /* primary: '(' expr ')'  */
+#line 217 "../src/parse/parser.ypp"
+               { (yyval.regexp) = ast.cap((yyvsp[-1].regexp)); }
+#line 1399 "src/parse/parser.cc"
+    break;
 
-#line 1397 "src/parse/parser.cc"
+
+#line 1403 "src/parse/parser.cc"
 
       default: break;
     }
@@ -1586,7 +1592,7 @@ yyreturnlab:
   return yyresult;
 }
 
-#line 209 "../src/parse/parser.ypp"
+#line 220 "../src/parse/parser.ypp"
 
 
 #pragma GCC diagnostic pop
@@ -1598,9 +1604,9 @@ extern "C" {
         }
     }
 
-    int yylex(context_t& context, Ast& ast) {
+    int yylex(YYSTYPE* yylval, context_t& context, Ast& ast) {
         int token;
-        if (context.input.scan(ast, token) != Ret::OK) {
+        if (context.input.scan(yylval, ast, token) != Ret::OK) {
             context.lexer_error = true;
             return TOKEN_ERROR;
         }

--- a/bootstrap/src/parse/parser.h
+++ b/bootstrap/src/parse/parser.h
@@ -44,6 +44,18 @@
 #if YYDEBUG
 extern int yydebug;
 #endif
+/* "%code requires" blocks.  */
+#line 1 "../src/parse/parser.ypp"
+
+/* pull in types to populate YYSTYPE: */
+#include "src/parse/ast.h"
+namespace re2c {
+    struct AstNode;
+    struct SemAct;
+    struct context_t;
+};
+
+#line 59 "src/parse/parser.h"
 
 /* Token kinds.  */
 #ifndef YYTOKENTYPE
@@ -77,7 +89,7 @@ extern int yydebug;
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 union YYSTYPE
 {
-#line 26 "../src/parse/parser.ypp"
+#line 37 "../src/parse/parser.ypp"
 
     const re2c::AstNode* regexp;
     const re2c::SemAct* semact;
@@ -86,7 +98,7 @@ union YYSTYPE
     const char* cstr;
     std::string* str;
 
-#line 90 "src/parse/parser.h"
+#line 102 "src/parse/parser.h"
 
 };
 typedef union YYSTYPE YYSTYPE;
@@ -95,7 +107,6 @@ typedef union YYSTYPE YYSTYPE;
 #endif
 
 
-extern YYSTYPE yylval;
 
 
 int yyparse (re2c::context_t& context, re2c::Ast& ast);

--- a/lib/lex.h
+++ b/lib/lex.h
@@ -1,13 +1,14 @@
 #ifndef _RE2C_LIB_LEX_
 #define _RE2C_LIB_LEX_
 
+#include "lib/parse.h"
 #include "src/msg/location.h"
 #include "src/regexp/re.h"
 #include "src/parse/ast.h"
 
 namespace re2c {
 
-int lex(const uint8_t*& pattern, Ast& ast);
+int lex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast);
 const AstNode* parse(const char* pattern, Ast& ast);
 extern const AstNode* regexp;
 

--- a/lib/lex.re
+++ b/lib/lex.re
@@ -9,7 +9,7 @@
 #include "parse.h"
 #include "lib/lex.h"
 
-extern YYSTYPE yylval;
+
 
 namespace re2c {
 
@@ -26,7 +26,7 @@ static int32_t lex_cls_chr(const uint8_t*&, uint32_t&);
     num = [0-9]+;
 */
 
-int lex(const uint8_t*& cur, Ast& ast) {
+int lex(YYSTYPE* yylval, const uint8_t*& cur, Ast& ast) {
     /*!stags:re2c format = "const uint8_t* @@;"; */
     const uint8_t* mar, *x, *y;
     bool neg = false;
@@ -48,31 +48,31 @@ int lex(const uint8_t*& cur, Ast& ast) {
     "["  { goto cls; }
 
     "{" @x num "}" {
-        if (!s_to_u32_unsafe(x, cur - 1, yylval.bounds.min)) goto err_cnt;
-        yylval.bounds.max = yylval.bounds.min;
+        if (!s_to_u32_unsafe(x, cur - 1, yylval->bounds.min)) goto err_cnt;
+        yylval->bounds.max = yylval->bounds.min;
         return TOKEN_COUNT;
     }
 
     "{" @x num "," @y num "}" {
-        if (!s_to_u32_unsafe(x, y - 1, yylval.bounds.min)
-            || !s_to_u32_unsafe(y, cur - 1, yylval.bounds.max)) goto err_cnt;
+        if (!s_to_u32_unsafe(x, y - 1, yylval->bounds.min)
+            || !s_to_u32_unsafe(y, cur - 1, yylval->bounds.max)) goto err_cnt;
         return TOKEN_COUNT;
     }
 
     "{" @x num ",}" {
-        if (!s_to_u32_unsafe(x, cur - 2, yylval.bounds.min)) goto err_cnt;
-        yylval.bounds.max = Ast::MANY;
+        if (!s_to_u32_unsafe(x, cur - 2, yylval->bounds.min)) goto err_cnt;
+        yylval->bounds.max = Ast::MANY;
         return TOKEN_COUNT;
     }
 
     "." {
-        yylval.regexp = ast.dot(NOWHERE);
+        yylval->regexp = ast.dot(NOWHERE);
         return TOKEN_REGEXP;
     }
 
     [^] \ nil {
         ast.temp_chars.push_back({cur[-1], NOWHERE});
-        yylval.regexp = ast.str(NOWHERE, false);
+        yylval->regexp = ast.str(NOWHERE, false);
         return TOKEN_REGEXP;
     }
 */
@@ -89,7 +89,7 @@ add:
 /*!local:re2c
     ""  { goto cls; }
     "]" {
-        yylval.regexp = ast.cls(NOWHERE, neg);
+        yylval->regexp = ast.cls(NOWHERE, neg);
         return TOKEN_REGEXP;
     }
 */

--- a/lib/parse.ypp
+++ b/lib/parse.ypp
@@ -1,3 +1,11 @@
+%code requires {
+/* pull in types to populate YYSTYPE: */
+#include "src/parse/ast.h"
+namespace re2c {
+    struct AstNode;
+};
+}
+
 %{
 
 #include <stdio.h>
@@ -12,14 +20,9 @@
 #include "src/util/nowarn_in_bison.h"
 
 using namespace re2c;
-
-extern "C" {
-    int yylex(const uint8_t*& pattern, Ast& ast);
-    void yyerror(const uint8_t* pattern, Ast&, const char* msg) RE2C_ATTR((noreturn));
-}
-
 %}
 
+%define api.pure full
 %lex-param {const uint8_t*& pattern}
 %lex-param {re2c::Ast& ast}
 %parse-param {const uint8_t*& pattern}
@@ -31,6 +34,14 @@ extern "C" {
     const re2c::AstNode* regexp;
     re2c::AstBounds bounds;
 };
+
+%{
+extern "C" {
+    int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast);
+    void yyerror(const uint8_t* pattern, Ast&, const char* msg) RE2C_ATTR((noreturn));
+}
+
+%}
 
 %token TOKEN_COUNT
 %token TOKEN_ERROR
@@ -77,8 +88,8 @@ extern "C" {
         exit(1);
     }
 
-    int yylex(const uint8_t*& pattern, Ast& ast) {
-        return lex(pattern, ast);
+    int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast) {
+        return lex(yylval, pattern, ast);
     }
 }
 

--- a/lib/regcomp.cc
+++ b/lib/regcomp.cc
@@ -22,7 +22,7 @@
 
 namespace re2c {
 
-int lex(const char* pattern);
+int lex(YYSTYPE* yylval, const char* pattern);
 const AstNode* regexp;
 
 } // namespace re2c

--- a/src/parse/lex.re
+++ b/src/parse/lex.re
@@ -21,7 +21,7 @@
 #include "src/util/string_utils.h"
 #include "parser.h"
 
-extern YYSTYPE yylval;
+
 
 namespace re2c {
 
@@ -404,18 +404,18 @@ loop: /*!local:re2c
 
 #define RET_TOK(t) do { token = t; return Ret::OK; } while(0)
 
-Ret Scanner::scan(Ast& ast, int& token) {
+Ret Scanner::scan(YYSTYPE* yylval, Ast& ast, int& token) {
     const uint8_t* p, *x, *y;
 scan:
     tok = cur;
     location = cur_loc();
 /*!local:re2c
 
-    "{"  { CHECK_RET(lex_code_in_braces(ast)); RET_TOK(TOKEN_CODE); }
-    ":=" { CHECK_RET(lex_code_indented(ast));  RET_TOK(TOKEN_CODE); }
+    "{"  { CHECK_RET(lex_code_in_braces(yylval, ast)); RET_TOK(TOKEN_CODE); }
+    ":=" { CHECK_RET(lex_code_indented(yylval, ast));  RET_TOK(TOKEN_CODE); }
 
     ":"? "=>" space* @p name {
-        yylval.cstr = ast.cstr(p, cur);
+        yylval->cstr = ast.cstr(p, cur);
         RET_TOK(tok[0] == ':' ? TOKEN_CJUMP : TOKEN_CNEXT);
     }
 
@@ -426,42 +426,42 @@ scan:
 
     "%}" | "*""/" { tok = cur; RET_TOK(0); }
 
-    "'"  { CHECK_RET(lex_str(ast, '\'',  yylval.regexp)); RET_TOK(TOKEN_REGEXP); }
-    "\"" { CHECK_RET(lex_str(ast, '"',   yylval.regexp)); RET_TOK(TOKEN_REGEXP); }
-    "["  { CHECK_RET(lex_cls(ast, false, yylval.regexp)); RET_TOK(TOKEN_REGEXP); }
-    "[^" { CHECK_RET(lex_cls(ast, true,  yylval.regexp)); RET_TOK(TOKEN_REGEXP); }
+    "'"  { CHECK_RET(lex_str(ast, '\'',  yylval->regexp)); RET_TOK(TOKEN_REGEXP); }
+    "\"" { CHECK_RET(lex_str(ast, '"',   yylval->regexp)); RET_TOK(TOKEN_REGEXP); }
+    "["  { CHECK_RET(lex_cls(ast, false, yylval->regexp)); RET_TOK(TOKEN_REGEXP); }
+    "[^" { CHECK_RET(lex_cls(ast, true,  yylval->regexp)); RET_TOK(TOKEN_REGEXP); }
 
     [@#] name {
-        yylval.regexp = ast.tag(tok_loc(), ast.cstr(tok + 1, cur), tok[0] == '#');
+        yylval->regexp = ast.tag(tok_loc(), ast.cstr(tok + 1, cur), tok[0] == '#');
         RET_TOK(TOKEN_REGEXP);
     }
 
     [*+?()|;/\\=$] { RET_TOK(*tok); }
 
     "{" [0-9]+ "}" {
-        if (!s_to_u32_unsafe (tok + 1, cur - 1, yylval.bounds.min)) {
+        if (!s_to_u32_unsafe (tok + 1, cur - 1, yylval->bounds.min)) {
             RET_FAIL(msg.error(tok_loc(), "repetition count overflow"));
         }
-        yylval.bounds.max = yylval.bounds.min;
+        yylval->bounds.max = yylval->bounds.min;
         RET_TOK(TOKEN_CLOSESIZE);
     }
 
     "{" [0-9]+ @p "," [0-9]+ "}" {
-        if (!s_to_u32_unsafe(tok + 1, p, yylval.bounds.min)) {
+        if (!s_to_u32_unsafe(tok + 1, p, yylval->bounds.min)) {
             RET_FAIL(msg.error(tok_loc(), "repetition lower bound overflow"));
-        } else if (!s_to_u32_unsafe(p + 1, cur - 1, yylval.bounds.max)) {
+        } else if (!s_to_u32_unsafe(p + 1, cur - 1, yylval->bounds.max)) {
             RET_FAIL(msg.error(tok_loc(), "repetition upper bound overflow"));
-        } else if (yylval.bounds.min > yylval.bounds.max) {
+        } else if (yylval->bounds.min > yylval->bounds.max) {
             RET_FAIL(msg.error(tok_loc(), "repetition lower bound exceeds upper bound"));
         }
         RET_TOK(TOKEN_CLOSESIZE);
     }
 
     "{" [0-9]+ ",}" {
-        if (!s_to_u32_unsafe (tok + 1, cur - 2, yylval.bounds.min)) {
+        if (!s_to_u32_unsafe (tok + 1, cur - 2, yylval->bounds.min)) {
             RET_FAIL(msg.error(tok_loc(), "repetition lower bound overflow"));
         }
-        yylval.bounds.max = std::numeric_limits<uint32_t>::max();
+        yylval->bounds.max = std::numeric_limits<uint32_t>::max();
         RET_TOK(TOKEN_CLOSESIZE);
     }
 
@@ -475,7 +475,7 @@ scan:
         if (!globopts->FFlag) {
             RET_FAIL(msg.error(tok_loc(), "curly braces for names only allowed with -F switch"));
         }
-        yylval.cstr = ast.cstr(tok + 1, cur - 1);
+        yylval->cstr = ast.cstr(tok + 1, cur - 1);
         RET_TOK(TOKEN_ID);
     }
 
@@ -485,12 +485,12 @@ scan:
         bool yes;
         CHECK_RET(lex_namedef_context_re2c(yes));
         if (!globopts->FFlag || yes) {
-            yylval.cstr = ast.cstr(tok, cur);
+            yylval->cstr = ast.cstr(tok, cur);
             RET_TOK(TOKEN_ID);
         }
         CHECK_RET(lex_namedef_context_flex(yes));
         if (yes) {
-            yylval.cstr = ast.cstr(tok, cur);
+            yylval->cstr = ast.cstr(tok, cur);
             mode = LexMode::FLEX_NAME;
             RET_TOK(TOKEN_FID);
         }
@@ -498,7 +498,7 @@ scan:
         // `ab*`: it should be `a(b)*`, not `(ab)*`
         cur = tok + 1;
         ast.temp_chars.push_back({tok[0], tok_loc()});
-        yylval.regexp = ast.str(tok_loc(), false);
+        yylval->regexp = ast.str(tok_loc(), false);
         RET_TOK(TOKEN_REGEXP);
     }
 
@@ -526,7 +526,7 @@ scan:
                            "the end of block"));
     }
 
-    "." { yylval.regexp = ast.dot(tok_loc()); RET_TOK(TOKEN_REGEXP); }
+    "." { yylval->regexp = ast.dot(tok_loc()); RET_TOK(TOKEN_REGEXP); }
 
     space+ { goto scan; }
 
@@ -592,7 +592,7 @@ error:
     RET_FAIL(msg.error(cur_loc(), "syntax error in condition list"));
 }
 
-Ret Scanner::lex_code_indented(Ast& ast) {
+Ret Scanner::lex_code_indented(YYSTYPE* yylval, Ast& ast) {
     const loc_t& loc = tok_loc();
     tok = cur;
 code: /*!re2c
@@ -609,19 +609,19 @@ indent: /*!re2c
         while (isspace(tok[0])) ++tok;
         uint8_t* p = cur;
         while (p > tok && isspace(p[-1])) --p;
-        yylval.semact = ast.sem_act(loc, ast.cstr(tok, p), nullptr, false);
+        yylval->semact = ast.sem_act(loc, ast.cstr(tok, p), nullptr, false);
         return Ret::OK;
     }
 */
 }
 
-Ret Scanner::lex_code_in_braces(Ast& ast) {
+Ret Scanner::lex_code_in_braces(YYSTYPE* yylval, Ast& ast) {
     const loc_t& loc = tok_loc();
     uint32_t depth = 1;
 code: /*!re2c
     "}" {
         if (--depth == 0) {
-            yylval.semact = ast.sem_act(loc, ast.cstr(tok, cur), nullptr, false);
+            yylval->semact = ast.sem_act(loc, ast.cstr(tok, cur), nullptr, false);
             return Ret::OK;
         }
         goto code;

--- a/src/parse/parser.ypp
+++ b/src/parse/parser.ypp
@@ -1,3 +1,13 @@
+%code requires {
+/* pull in types to populate YYSTYPE: */
+#include "src/parse/ast.h"
+namespace re2c {
+    struct AstNode;
+    struct SemAct;
+    struct context_t;
+};
+}
+
 %{
 
 #pragma GCC diagnostic push
@@ -10,7 +20,7 @@
 using namespace re2c;
 
 extern "C" {
-    int yylex(context_t& context, Ast& ast);
+    int yylex(YYSTYPE* yylval, context_t& context, Ast& ast);
     void yyerror(context_t& context, Ast& ast, const char*);
 }
 
@@ -18,6 +28,7 @@ extern "C" {
 
 %start spec
 
+%define api.pure full
 %lex-param {re2c::context_t& context}
 %lex-param {re2c::Ast& ast}
 %parse-param {re2c::context_t& context}
@@ -217,9 +228,9 @@ extern "C" {
         }
     }
 
-    int yylex(context_t& context, Ast& ast) {
+    int yylex(YYSTYPE* yylval, context_t& context, Ast& ast) {
         int token;
-        if (context.input.scan(ast, token) != Ret::OK) {
+        if (context.input.scan(yylval, ast, token) != Ret::OK) {
             context.lexer_error = true;
             return TOKEN_ERROR;
         }

--- a/src/parse/scanner.h
+++ b/src/parse/scanner.h
@@ -11,6 +11,7 @@
 #include "src/msg/location.h"
 #include "src/parse/input.h"
 #include "src/parse/lex.h"
+#include "src/parse/parser.h"
 #include "src/encoding/enc.h"
 #include "src/encoding/utf8.h"
 #include "src/util/allocator.h"
@@ -51,7 +52,7 @@ class Scanner: private ScannerState {
     Ret include(const std::string& filename, uint8_t* at) NODISCARD;
     Ret gen_dep_file() const NODISCARD;
     Ret echo(Output& out, std::string& block_name, InputBlock& kind) NODISCARD;
-    Ret scan(Ast& ast, int& token) NODISCARD;
+    Ret scan(YYSTYPE* yylval, Ast& ast, int& token) NODISCARD;
     Ret lex_conf(Opt& opts) NODISCARD;
 
   private:
@@ -71,8 +72,8 @@ class Scanner: private ScannerState {
     Ret lex_name_list(OutAllocator& alc, BlockNameList** ptail) NODISCARD;
     Ret lex_block(Output& out, CodeKind kind, uint32_t indent, uint32_t mask) NODISCARD;
     Ret lex_block_end(Output& out, bool allow_garbage = false) NODISCARD;
-    Ret lex_code_indented(Ast& ast) NODISCARD;
-    Ret lex_code_in_braces(Ast& ast) NODISCARD;
+    Ret lex_code_indented(YYSTYPE* yylval, Ast& ast) NODISCARD;
+    Ret lex_code_in_braces(YYSTYPE* yylval, Ast& ast) NODISCARD;
     Ret try_lex_string_in_code(uint8_t quote) NODISCARD;
     Ret lex_c_comment() NODISCARD;
     Ret lex_cpp_comment() NODISCARD;


### PR DESCRIPTION
Before the change parsers relied on `YYSTYPE` global variable.
Not very handy for libre2c if it's expected to be used in reentrant
or multi-threaded contexts.

The change enables `%define api.pure full` and adjusts lexer calls
to explicitly pass through `YYSTYPE` around.

`%define api.pure full` is preferred to `%pure-parser` (deprecated in
2008, around Bison 2.3b). Should be safe to use.