### PR TITLE
bison parsers: mark static yylex() and yyerror()

### DIFF
--- a/bootstrap/lib/parse.cc
+++ b/bootstrap/lib/parse.cc
@@ -137,8 +137,8 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
 #line 38 "../lib/parse.ypp"
 
 extern "C" {
-    int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast);
-    void yyerror(const uint8_t* pattern, Ast&, const char* msg) RE2C_ATTR((noreturn));
+    static int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast);
+    static void yyerror(const uint8_t* pattern, Ast&, const char* msg) RE2C_ATTR((noreturn));
 }
 
 
@@ -1354,12 +1354,12 @@ yyreturnlab:
 #pragma GCC diagnostic pop
 
 extern "C" {
-    void yyerror(const uint8_t* pattern, Ast&, const char* msg) {
+    static void yyerror(const uint8_t* pattern, Ast&, const char* msg) {
         fprintf(stderr, "%s (on RE %s)", msg, pattern);
         exit(1);
     }
 
-    int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast) {
+    static int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast) {
         return lex(yylval, pattern, ast);
     }
 }

--- a/bootstrap/src/parse/parser.cc
+++ b/bootstrap/src/parse/parser.cc
@@ -80,8 +80,8 @@
 using namespace re2c;
 
 extern "C" {
-    int yylex(YYSTYPE* yylval, context_t& context, Ast& ast);
-    void yyerror(context_t& context, Ast& ast, const char*);
+    static int yylex(YYSTYPE* yylval, context_t& context, Ast& ast);
+    static void yyerror(context_t& context, Ast& ast, const char*);
 }
 
 
@@ -1598,13 +1598,13 @@ yyreturnlab:
 #pragma GCC diagnostic pop
 
 extern "C" {
-    void yyerror(context_t& context, Ast&, const char* s) {
+    static void yyerror(context_t& context, Ast&, const char* s) {
         if (!context.lexer_error) { // lexer error has already been reported
             context.input.msg.error(context.input.tok_loc(), "%s", s);
         }
     }
 
-    int yylex(YYSTYPE* yylval, context_t& context, Ast& ast) {
+    static int yylex(YYSTYPE* yylval, context_t& context, Ast& ast) {
         int token;
         if (context.input.scan(yylval, ast, token) != Ret::OK) {
             context.lexer_error = true;

--- a/lib/parse.ypp
+++ b/lib/parse.ypp
@@ -37,8 +37,8 @@ using namespace re2c;
 
 %{
 extern "C" {
-    int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast);
-    void yyerror(const uint8_t* pattern, Ast&, const char* msg) RE2C_ATTR((noreturn));
+    static int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast);
+    static void yyerror(const uint8_t* pattern, Ast&, const char* msg) RE2C_ATTR((noreturn));
 }
 
 %}
@@ -83,12 +83,12 @@ primary
 #pragma GCC diagnostic pop
 
 extern "C" {
-    void yyerror(const uint8_t* pattern, Ast&, const char* msg) {
+    static void yyerror(const uint8_t* pattern, Ast&, const char* msg) {
         fprintf(stderr, "%s (on RE %s)", msg, pattern);
         exit(1);
     }
 
-    int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast) {
+    static int yylex(YYSTYPE* yylval, const uint8_t*& pattern, Ast& ast) {
         return lex(yylval, pattern, ast);
     }
 }

--- a/src/parse/parser.ypp
+++ b/src/parse/parser.ypp
@@ -20,8 +20,8 @@ namespace re2c {
 using namespace re2c;
 
 extern "C" {
-    int yylex(YYSTYPE* yylval, context_t& context, Ast& ast);
-    void yyerror(context_t& context, Ast& ast, const char*);
+    static int yylex(YYSTYPE* yylval, context_t& context, Ast& ast);
+    static void yyerror(context_t& context, Ast& ast, const char*);
 }
 
 %}
@@ -222,13 +222,13 @@ primary
 #pragma GCC diagnostic pop
 
 extern "C" {
-    void yyerror(context_t& context, Ast&, const char* s) {
+    static void yyerror(context_t& context, Ast&, const char* s) {
         if (!context.lexer_error) { // lexer error has already been reported
             context.input.msg.error(context.input.tok_loc(), "%s", s);
         }
     }
 
-    int yylex(YYSTYPE* yylval, context_t& context, Ast& ast) {
+    static int yylex(YYSTYPE* yylval, context_t& context, Ast& ast) {
         int token;
         if (context.input.scan(yylval, ast, token) != Ret::OK) {
             context.lexer_error = true;


### PR DESCRIPTION
Unused exported symbols are detected by uselex:

    yyerror: [R]: exported from: src/parse/re2go-parser.o src/parse/parser.o src/parse/re2rust-parser.o
    yylex: [R]: exported from: src/parse/re2go-parser.o src/parse/parser.o src/parse/re2rust-parser.o