### PR TITLE
src/util/check.h: always use DCHECK(x) argument to avoid warnings

### DIFF
--- a/src/util/check.h
+++ b/src/util/check.h
@@ -19,7 +19,9 @@
 
 #else // RE2C_DEBUG
 
-#define DCHECK(x)
+/* In non-debug mode we still produce a statement and use 'x'
+   to avoid complains about unused variables. */
+#define DCHECK(x) do {} while (false && (x))
 
 #endif // RE2C_DEBUG
 


### PR DESCRIPTION
Without the change on `gcc-13` build warns as:

    ./src/parse/input.h: In member function 're2c::loc_t re2c::Input::cur_loc() const':
    ./src/parse/input.h:139:20: warning: unused variable 'p' [-Wunused-variable]
      139 |     const uint8_t* p = cur;
          |                    ^

The change turns `DCHECK(x)` into a statement that uses `x`.