### PR TITLE
Introduce Dlang codegen.  

### DIFF
--- a/src/codegen/pass2_generate.cc
+++ b/src/codegen/pass2_generate.cc
@@ -1438,7 +1438,7 @@ static void gen_cond_enum(Scratchbuf& buf,
         CodeList* stmts = code_list(alc);
         CodeList* block = code_list(alc);
 
-        if (opts->lang == Lang::C) {
+        if (opts->lang == Lang::C || opts->lang == Lang::D) {
             start = buf.cstr("enum ").str(opts->api_cond_type).cstr(" {").flush();
             end = "};";
             for (const StartCond& cond : conds) {
@@ -1745,6 +1745,9 @@ LOCAL_NODISCARD(Ret gen_yymax(Output&  output, Code* code)) {
         case Lang::C:
             code->text = buf.cstr("#define ").cstr(varname).cstr(" ").u64(max).flush();
             break;
+        case Lang::D:
+            code->text = buf.cstr("enum ").cstr(varname).cstr(" = ").u64(max).flush();
+            break;
         case Lang::GO:
             code->text = buf.cstr("var ").cstr(varname).cstr(" int = ").u64(max).flush();
             break;
@@ -1781,9 +1784,18 @@ CodeList* gen_bitmap(Output& output, const CodeBitmap* bitmap, const std::string
     CodeList* stmts = code_list(alc);
 
     const std::string& name = bitmap_name(opts, cond);
-    text = opts->lang == Lang::C
-           ? o.cstr("static const unsigned char ").str(name).cstr("[] = {").flush()
-           : o.str(name).cstr(" := []byte{").flush();
+    switch (opts->lang) {
+        case Lang::C:
+            text = o.cstr("static const unsigned char ").str(name).cstr("[] = {").flush();
+            break;
+        case Lang::D:
+            text = o.cstr("immutable char[] ").str(name).cstr(" = {").flush();
+            break;
+        case Lang::GO:
+        case Lang::RUST:
+            text = o.str(name).cstr(" := []byte{").flush();
+            break;
+    }
     append(stmts, code_text(alc, text));
 
     CodeList* block = code_list(alc);

--- a/src/codegen/pass4_render.cc
+++ b/src/codegen/pass4_render.cc
@@ -36,13 +36,14 @@ static void render_line_info(
     if (!opts->line_dirs) return;
 
     switch (opts->lang) {
+    case Lang::C:
+    case Lang::D:
+        // C/C++ and D: #line <line-number> <filename>
+        o << "#line " << line << " \"" << fname << "\"\n";
+        break;
     case Lang::GO:
         // Go: //line <filename>:<line-number>
         o << "//line \"" << fname << "\":" << line << "\n";
-        break;
-    case Lang::C:
-        // C/C++: #line <line-number> <filename>
-        o << "#line " << line << " \"" << fname << "\"\n";
         break;
     case Lang::RUST:
         // For Rust line directives should be removed by `remove_empty` pass.
@@ -52,7 +53,7 @@ static void render_line_info(
 
 static bool oneline_if(const CodeIfTE* code, const opt_t* opts) {
     const Code* first = code->if_code->head;
-    return opts->lang == Lang::C // Go and Rust require braces
+    return (opts->lang == Lang::C || opts->lang == Lang::D) // Go and Rust require braces
            && code->oneline
            && code->else_code == nullptr
            && first
@@ -136,6 +137,18 @@ static const char* var_type_c(VarType type, const opt_t* opts) {
     return nullptr;
 }
 
+static const char* var_type_d(VarType type, const opt_t* opts) {
+    switch (type) {
+    case VarType::INT:
+        return "int";
+    case VarType::UINT:
+        return "uint";
+    case VarType::YYCTYPE:
+        return opts->api_char_type.c_str();
+    }
+    return nullptr;
+}
+
 static const char* var_type_go(VarType type, const opt_t* opts) {
     switch (type) {
     case VarType::INT:
@@ -168,6 +181,13 @@ static void render_var(RenderContext& rctx, const CodeVar* var) {
     switch (opts->lang) {
     case Lang::C:
         os << ind << var_type_c(var->type, opts) << " " << var->name;
+        if (var->init) os << " = " << var->init;
+        os << ";" << std::endl;
+        ++rctx.line;
+        break;
+
+    case Lang::D:
+        os << ind << var_type_d(var->type, opts) << " " << var->name;
         if (var->init) os << " = " << var->init;
         os << ";" << std::endl;
         ++rctx.line;
@@ -247,6 +267,21 @@ static void render_case_range(
         if (!last) {
             os << std::endl;
             ++rctx.line;
+        }
+        break;
+
+    case Lang::D:
+        os << "case ";
+        render_number(rctx, low, type);
+        if (low != upp) {
+            os << ": .. case ";
+            render_number(rctx, upp, type);
+        }
+        os << ":";
+        if (!last) {
+            os << std::endl;
+            os << indent(rctx.ind + 1, opts->indent_str) << "goto case;" << std::endl;
+            rctx.line += 2;
         }
         break;
 
@@ -447,6 +482,9 @@ static void render_loop(RenderContext& rctx, const CodeList* loop) {
     case Lang::C:
         os << indent(rctx.ind, opts->indent_str) << "for (;;)";
         break;
+    case Lang::D:
+        os << indent(rctx.ind, opts->indent_str) << "while (true)";
+        break;
     case Lang::GO:
         // In Go label is on a separate line with zero indent.
         if (!opts->label_loop.empty()) {
@@ -620,6 +658,7 @@ static void render_abort(RenderContext& rctx) {
     os << indent(rctx.ind, opts->indent_str);
     switch (opts->lang) {
     case Lang::C:
+    case Lang::D:
         DCHECK(opts->state_abort);
         os << "abort();";
         break;

--- a/src/constants.h
+++ b/src/constants.h
@@ -14,6 +14,7 @@ enum class Target: uint32_t {
 
 enum class Lang: uint32_t {
     C,
+    D,
     GO,
     RUST
 };

--- a/src/options/opt.cc
+++ b/src/options/opt.cc
@@ -244,7 +244,8 @@ LOCAL_NODISCARD(Ret fix_mutopt(const conopt_t& glob,
     if (is_default.state_set_param)  real.state_set_param  = real.api_sigil;
     if (is_default.tags_expression)  real.tags_expression  = real.api_sigil;
     if (is_default.cond_goto) {
-        real.cond_goto = "goto " + real.cond_goto_param + (glob.lang == Lang::C ? ";" : "");
+        bool need_semi = (glob.lang == Lang::C || glob.lang == Lang::D);
+        real.cond_goto = "goto " + real.cond_goto_param + (need_semi ? ";" : "");
     }
     // "startlabel" configuration exists in two variants: string and boolean, and the string one
     // overrides the boolean one
@@ -271,20 +272,21 @@ LOCAL_NODISCARD(Ret fix_mutopt(const conopt_t& glob,
         // In Go `continue` statements have labels, use it to avoid ambiguity.
         if (is_default.label_loop) real.label_loop = "yyl";
     }
-
     // errors
     if (glob.lang != Lang::C) {
         if (glob.target == Target::SKELETON) {
             RET_FAIL(error("skeleton is not supported for non-C backends"));
         }
-        if (real.api == Api::DEFAULT) {
-            RET_FAIL(error("pointer API is not supported for non-C backends"));
-        }
         if (real.cgoto) {
             RET_FAIL(error("-g, --computed-gotos option is not supported for non-C backends"));
         }
+    }
+    if (!(glob.lang == Lang::C || glob.lang == Lang::D)) {
         if (real.case_ranges) {
-            RET_FAIL(error("--case-ranges option is not supported for non-C backends"));
+    	    RET_FAIL(error("--case-ranges option is supported only for C and D backends"));
+        }
+        if (real.api == Api::DEFAULT) {
+    	    RET_FAIL(error("pointer API is supported only for C and D backends"));
         }
     }
     if (real.fill_eof != NOEOF) {

--- a/src/options/parse_opts.re
+++ b/src/options/parse_opts.re
@@ -212,8 +212,9 @@ opt_long: /*!local:re2c
 */
 
 opt_lang: /*!local:re2c
-    * { ERRARG("--lang", "c | go | rust", *argv); }
+    * { ERRARG("--lang", "c | d | go | rust", *argv); }
     "c"    end { globopts.lang = Lang::C;    goto opt; }
+    "d"    end { globopts.lang = Lang::D;    goto opt; }
     "go"   end { globopts.lang = Lang::GO;   goto opt; }
     "rust" end { globopts.lang = Lang::RUST; goto opt; }
 */

--- a/test/golang/006_error_default_api.go
+++ b/test/golang/006_error_default_api.go
@@ -1,1 +1,1 @@
-re2c: error: pointer API is not supported for non-C backends
+re2c: error: pointer API is supported only for C and D backends

--- a/test/golang/007_error_default_api.go
+++ b/test/golang/007_error_default_api.go
@@ -1,1 +1,1 @@
-re2c: error: pointer API is not supported for non-C backends
+re2c: error: pointer API is supported only for C and D backends

--- a/test/golang/010_error_case_ranges.go
+++ b/test/golang/010_error_case_ranges.go
@@ -1,1 +1,1 @@
-re2c: error: --case-ranges option is not supported for non-C backends
+re2c: error: --case-ranges option is supported only for C and D backends


### PR DESCRIPTION
Currently builds and passes every test with run_tests.py except: `golang/010_error_case_ranges.re`. One of the main differences from Go/Rust is that D supports case ranges like C. It also supports generic `enum`s which are just compile time constants which can be used basically like a C define macro. So far from converting the example programs the codegen seems to be working well.  I mostly just grepped for any use of `Lang::` and copied the existing code and made the smallest modifications I could to have it generate valid D code.