### PR TITLE
.github/workflows/ci-cmake.yml: avoid `pwd` and use `${{ github.works…

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -135,9 +135,9 @@ jobs:
         id: build-info
         run: |
           if echo "${{ matrix.name }}" | grep -q "ootree"; then
-            BUILD_DIR="$(pwd)/.build/${{ matrix.name }}-full"
+            BUILD_DIR="${{ github.workspace }}/.build/${{ matrix.name }}-full"
           else
-            BUILD_DIR="$(pwd)"
+            BUILD_DIR="${{ github.workspace }}"
           fi
           echo "BUILD_DIR=$BUILD_DIR" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
…pace }}`

It loks like at least in `windows` `actions/upload-artifact@v4` CI step fails to collect files at `${{ steps.build-info.outputs.BUILD_DIR }}/test_[0-9]*`

My theory is that `glob` is not able to match paths like

    `D:/a/re2c/re2c/install-2`

against theit unix-like form of

    `/d/a/re2c/re2c/install-2`

I suspect that `pwd` returns us the second form while `${{ github.workspace }}` might keep an original form.