### PR TITLE
Use Python version in find_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,8 @@ option(RE2C_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(RE2C_REGEN_BENCHMARKS "Regenerate C code for benchmarks" OFF)
 
 # checks for programs
-find_package(Python3 COMPONENTS Interpreter)
-# starting from cmake 3.19 find_package can do version check, but we are on 3.12
-if(Python3_VERSION VERSION_LESS 3.7)
-    message(FATAL_ERROR "python version 3.7 or higher is required")
-endif()
+find_package(Python3 3.7 REQUIRED COMPONENTS Interpreter)
+
 if(RE2C_REBUILD_DOCS)
     execute_process(
         COMMAND "${Python3_EXECUTABLE}" -c "import docutils"


### PR DESCRIPTION
This simplifies the find_package() call. The version in find_package() has been initially supported in CMake 2 and 3. Version ranges (versionMin...[<]versionMax), on the other hand, are only supported by CMake 3.19+.

And this also helps a bit when adding re2c as a FetchContent dependency in CMake project where finding Python is not necessary and can be disabled with CMAKE_DISABLE_FIND_PACKAGE_Python3 variable.