### PR TITLE
Increase the Cmake minimum version to allow using CMAKE_MSVC_RUNTIME_LIBRARY flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 project(re2c VERSION 4.0 HOMEPAGE_URL "https://re2c.org/")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
In Cmake 3.15 introduces CMAKE_MSVC_RUNTIME_LIBRARY
https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html
This flag is very useful to build a static binary on Windows by using `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded`