### PR TITLE
Use std::max_align_t instead of max_align_t.

### DIFF
--- a/src/util/allocator.h
+++ b/src/util/allocator.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <stddef.h>
+#include <cstddef>
 #include <algorithm>
 #include <vector>
 
@@ -82,7 +82,7 @@ class slab_allocator_t {
 // Use alignment based on pointer size: 32-bit platforms need stronger alignment
 // for 64-bit types (double, long long), while 64-bit platforms are already
 // sufficiently aligned with pointer-sized alignment.
-constexpr size_t ALLOCATOR_ALIGNMENT = (sizeof(void*) == 4) ? alignof(max_align_t) : sizeof(void*);
+constexpr size_t ALLOCATOR_ALIGNMENT = (sizeof(void*) == 4) ? alignof(std::max_align_t) : sizeof(void*);
 
 // Use different types to prevent accidentally mixing allocators for data with different life spans.
 using AstAllocator = slab_allocator_t<AllocatorKind::AST, 16 * 4096, ALLOCATOR_ALIGNMENT>;


### PR DESCRIPTION
This fixes the following build failure on OS X 10.9 and earlier when using contemporaneous versions of Apple clang:

```
In file included from ../src/options/parse_opts.re:6:
In file included from ./src/dfa/dfa.h:12:
In file included from ./src/dfa/tcmd.h:10:
./src/util/allocator.h:85:71: error: unknown type name 'max_align_t'; did you mean 'std::max_align_t'?
constexpr size_t ALLOCATOR_ALIGNMENT = (sizeof(void*) == 4) ? alignof(max_align_t) : sizeof(void*);
                                                                      ^~~~~~~~~~~
                                                                      std::max_align_t
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cstddef:55:21: note: 'std::max_align_t' declared here
typedef long double max_align_t;
                    ^
```
