### PR TITLE
Fix negative char2class[] index on high-byte input in libre2c DFA matchers

### DIFF
--- a/lib/regexec_dfa.cc
+++ b/lib/regexec_dfa.cc
@@ -35,7 +35,7 @@ int regexec_dfa(
 
     for (;;) {
         s = dfa->states[i];
-        const int32_t c = *p++;
+        const size_t c = static_cast<uint8_t>(*p++);
         const size_t j = preg->char2class[c];
         i = s->arcs[j];
 
@@ -102,7 +102,7 @@ subhistory_t* regparse_dfa(const regex_t* preg, const char* string, size_t nmatc
 
     for (;;) {
         s = dfa->states[i];
-        const int32_t c = *p++;
+        const size_t c = static_cast<uint8_t>(*p++);
         const size_t j = preg->char2class[c];
         i = s->arcs[j];
 

--- a/lib/regexec_dfa_multipass.cc
+++ b/lib/regexec_dfa_multipass.cc
@@ -27,7 +27,7 @@ static MpTdfaBacklink forward_pass(const regex_t* preg, const char* string, size
 
     log.clear();
     for (size_t stidx = 0;;) {
-        const int32_t chr = *strptr++;
+        const size_t chr = static_cast<uint8_t>(*strptr++);
         const size_t cls = preg->char2class[chr];
 
         const MpTdfaState* state = states[stidx];


### PR DESCRIPTION
## Bug

In `lib/regexec_dfa.cc` (`regexec_dfa()`, `regparse_dfa()`) and `lib/regexec_dfa_multipass.cc` (`forward_pass()`, shared by the `regexec_dfa_multipass<>`, `regparse_dfa_multipass<>`, and `regtstring_dfa_multipass<>` template instances), the next input byte is read as `*p++` into a plain `int32_t`/`chr`, and then used directly to index `preg->char2class[]`:

```cpp
const int32_t c = *p++;
const size_t j = preg->char2class[c];
```

`char` is signed by default on x86/x64. Any input byte `>= 0x80` sign-extends to a negative `int32_t`, so `char2class[c]` reads memory before the start of the 257-element `size_t` array allocated for it in `regcomp.cc` (`preg->char2class = new size_t[257];`). This is an out-of-bounds heap read whenever `regexec()`/`regparse()` is called on a regex compiled without `REG_NFA` (i.e. the default DFA-based matcher) and the input string contains a byte `>= 0x80`.

I reproduced this locally with a minimal harness (`regcomp(&re, ".a", REG_EXTENDED)` + `regexec()` on a string starting with each byte `0x01`-`0xFF`): with the code as it stands on `master`, this **segfaults** on high-byte input; after the fix below it passes cleanly for all 254 non-newline byte values.

## Fix

Read the byte through `static_cast<uint8_t>(...)` before using it as an index, matching the pattern already used for exactly this purpose in the NFA matchers (`regexec_nfa_leftmost.cc`, `regexec_nfa_leftmost_trie.cc`, `regexec_nfa_posix.cc`, `regexec_nfa_posix_trie.cc`):

```cpp
const size_t c = static_cast<uint8_t>(*p++);
const size_t j = preg->char2class[c];
```

The `== 0` end-of-input check further down is unaffected, since the cast leaves `0` unchanged.

Three call sites are affected across the two files (two in `regexec_dfa.cc`, one shared forward pass in `regexec_dfa_multipass.cc`).

## Testing

- Rebuilt with `-DRE2C_BUILD_LIBS=ON -DRE2C_BUILD_TESTS=ON` (MinGW/g++ 8.1.0) and ran the existing `test_libre2c` suite: passes both before and after this change (it doesn't happen to cover high-byte input, which is why this went unnoticed).
- Wrote a small standalone reproduction linking directly against the built `libre2c` static library, looping `regcomp(&re, ".a", REG_EXTENDED)` + `regexec()` over every byte value `0x01`-`0xFF` (skipping `0x0a`, since `.` conventionally excludes newline, unrelated to this bug): segfaults on the pre-fix code, passes cleanly after the fix.